### PR TITLE
Phase 10: composite poster bytes → object storage; TMDB → per-pod FS

### DIFF
--- a/RESILIENCE.md
+++ b/RESILIENCE.md
@@ -419,6 +419,83 @@ Highlights:
 
 ---
 
+## Phase 10 — Composite bytes to object storage; TMDB cache back to filesystem
+
+**Branch:** `phase-10-composite-blobstore`
+**Status:** implementation complete, codex review pending
+
+**Motivation:** Phase 3 put TMDB poster/logo bytes behind the blobstore abstraction and left composite (rendered) bytes in the relational backend as BYTEA. That was the wrong way round:
+
+- TMDB's own CDN (`image.tmdb.org`) is the source of truth for poster/logo bytes — mirroring it across replicas via S3 buys very little.
+- Composite renders are the unique work product. They scale with `unique(imdb_id × type × params_hash)` and are the bigger driver of DB storage cost.
+- A CDN in front of the composite-cache S3 bucket means clients pull bytes directly from the CDN — the app pod isn't on the read path at all.
+
+**Architecture after Phase 10:**
+
+```text
+TMDB CDN (image.tmdb.org)
+   │
+   ▼
+[ per-pod emptyDir cache ]   ← TMDB poster/logo bytes; ephemeral, re-warms on pod restart
+   │
+   ▼
+[ render pipeline ]
+   │  (writes once)
+   ▼
+[ S3 / B2 bucket ]   ← composite-poster JPEGs; the unique work product
+   │
+   ▼  (Bandwidth Alliance: B2→Cloudflare free)
+[ Cloudflare custom domain ]   ← posters.postersplus.elfhosted.com
+   │
+   ▼
+[ Stremio client ]   ← 302'd here from /poster on cache hit
+```
+
+**Code changes:**
+
+- `blobstore/__init__.py` — drops `BUCKET_TMDB_POSTERS` / `BUCKET_TMDB_LOGOS`; adds `BUCKET_COMPOSITES`. Adds `delete()` to the public API for evictions.
+- `blobstore/local.py` — atomic write via temp+rename; single bucket (`composites`) under `COMPOSITE_BLOB_DIR`.
+- `blobstore/s3.py` — adds `delete()`; everything else unchanged.
+- `storage/sqlite_backend.py` + `storage/postgres_backend.py`:
+  - `get_cached_tmdb_poster` / `get_cached_tmdb_logo` — reverted to upstream-style sync filesystem ops (per-pod cache).
+  - `get_cached_final_poster` — async; reads metadata row, then bytes via `blobstore.get(BUCKET_COMPOSITES, …)`.
+  - `set_cached_final_poster` — async; writes blob first (so the metadata row is never present without a backing blob), then upserts the row.
+  - `get_cached_final_poster_url()` — new sync function returning the public CDN URL when configured.
+  - Schema migration: `final_poster_cache` loses the `jpeg_bytes` BLOB/BYTEA column. SQLite uses `ALTER TABLE … DROP COLUMN` (3.35+) with a table-rebuild fallback for older versions; Postgres uses `ALTER TABLE … DROP COLUMN IF EXISTS`. Existing rows are preserved but bytes are lost — cache refills via TTL.
+- `cache.py` — async wrappers for composite; sync wrappers for TMDB; new `get_cached_final_poster_url` re-export.
+- `tmdb.py` — drops `await` from the 4 TMDB poster/logo callsites (back to sync).
+- `main.py` — composite-cache-hit path: if `get_cached_final_poster_url(key)` returns a URL, emit a `302` with `Location: <cdn-url>` (+ optional `Cache-Control` from `CDN_CACHE_TTL`). Otherwise stream bytes inline (private/local deployments). `await` added to the two composite cache callsites.
+- `config.py` — adds `COMPOSITE_BLOB_DIR=/app/cache/composites`.
+
+**Infra changes:**
+
+- `infra/postersplus/configmap-postersplus-env.yaml` — `OBJECT_STORE_URL` points at the B2 bucket (`s3://postersplus-composites?endpoint=https://s3.us-west-002.backblazeb2.com&region=us-west-002`); `OBJECT_STORE_PUBLIC_URL=https://posters.postersplus.elfhosted.com`.
+- TMDB cache: `/app/cache` emptyDir mount (already configured in the HelmRelease) is enough — per-pod ephemeral storage.
+
+**Verified end-to-end:**
+
+- SQLite + local blobstore: composite write+read round-trip; `url_for()` returns `None` (no public URL); TMDB sync FS round-trip preserved.
+- Migration from legacy schema: pre-existing SQLite DB with `jpeg_bytes BLOB` column → init_db drops the column, keeps rows. Same for Postgres via `ALTER TABLE DROP COLUMN IF EXISTS`.
+- Postgres + S3 (MinIO): write composite → metadata row in Postgres + bytes in S3 at `composites/<key>`; `url_for()` returns `https://posters.example.com/composites/<key>` matching configured public URL.
+- Container image (uid 568 + read-only + tmpfs): boots; `/live` 200; `/ready` 200.
+
+**Net data-layer change:**
+
+- Postgres `final_poster_cache` table goes from ~150 KB/row average → ~50 bytes/row (cache_key + cached_at). At 1M rows that's 150 GB → 50 MB.
+- Composite bytes live in B2 (free CF egress) with per-object cost; pruned by `COMPOSITE_CACHE_TTL` (TTL-based deletion on read) + the existing `COMPOSITE_MAX_ENTRIES` LRU cap.
+
+**Codex review (2026-05-23):** two P2 findings, both fixed:
+
+- **[P2]** The CDN-redirect path still fetched bytes from S3 before 302'ing — `get_cached_final_poster` (which does a `blobstore.get`) was called before checking if a CDN URL was available. Defeated the whole point of CDN offload. **Fixed:** added `is_cached_final_poster_fresh(cache_key)` — a lightweight metadata-row+TTL probe with no blob I/O. `/poster` now branches *first* on `OBJECT_STORE_PUBLIC_URL`: if set, freshness-probe + 302; if not, fall through to the inline-bytes path.
+- **[P2]** `prune_caches()` deleted expired metadata rows but left the blobstore objects orphaned forever. **Fixed:** `prune_caches` is now async; it captures the expiring `cache_key`s before the DELETE, then `await blobstore.delete()`s each one after commit. Same pattern in both SQLite and Postgres backends.
+
+**Known follow-ups:**
+
+- B2 lifecycle rule could enforce TTL server-side as a defence-in-depth in case the prune loop ever misses a cycle. Adding a `Lifecycle` rule that auto-deletes objects older than `COMPOSITE_CACHE_TTL` is a one-line bucket setting.
+- Could expose `postersplus_composite_cdn_hits_total` metric (incremented on every 302) so dashboards can see the CDN-vs-inline split.
+
+---
+
 ## Codex review log
 
 Per-phase second opinion via `~/.claude/bin/codex-review`. Findings recorded inline below.

--- a/blobstore/__init__.py
+++ b/blobstore/__init__.py
@@ -5,15 +5,22 @@ Active backend chosen at import time by config.OBJECT_STORE_URL:
   * unset / empty  → blobstore.local (filesystem, upstream default)
   * s3:// URL      → blobstore.s3 (S3-compatible, opt-in)
 
-Buckets currently in use:
+Holds **final composite posters** — the fully-rendered, watermarked /poster
+output. Each unique render-param combination is a separate entry. With S3
++ a CDN public URL (OBJECT_STORE_PUBLIC_URL), /poster redirects clients
+straight to the CDN on a cache hit and the app pod isn't on the read path
+at all.
 
-  * ``tmdb-posters`` — base poster images fetched from TMDB (JPEG)
-  * ``tmdb-logos``   — title logos fetched from TMDB (PNG)
+Not held here:
 
-Composite poster JPEGs remain in the relational backend (the final_poster_cache
-table). They could move here in a future phase but the table is bounded by
-COMPOSITE_MAX_ENTRIES and TTL so the trade-off is less compelling than for
-the upstream TMDB blobs.
+  * TMDB poster/logo bytes — those land on the pod's local filesystem
+    under TMDB_POSTER_CACHE_DIR / TMDB_LOGO_CACHE_DIR. They're a per-pod
+    latency-optimisation cache in front of TMDB's own CDN; sharing them
+    across replicas via S3 buys very little (TMDB's CDN is already fast)
+    while complicating the data path. Pod restarts re-warm them in the
+    first few minutes of traffic.
+  * Rating / quality / metadata / digital-release / trending — small
+    JSON-ish data, stays in the relational backend.
 """
 import logging
 
@@ -28,6 +35,7 @@ _PUBLIC_API = (
     "ping",
     "get",
     "put",
+    "delete",
     "url_for",
 )
 
@@ -58,6 +66,9 @@ BACKEND_KIND: str = "s3" if _backend.__name__.endswith(".s3") else "local"
 __all__ = list(_PUBLIC_API) + ["BACKEND_KIND"]
 
 
-# Bucket constants — single source of truth so a typo can't fork the keyspace.
-BUCKET_TMDB_POSTERS: str = "tmdb-posters"
-BUCKET_TMDB_LOGOS: str   = "tmdb-logos"
+# Bucket constants — single source of truth.
+#
+# Today only the composite-poster bytes live here. Earlier Phase 3 also
+# proxied TMDB poster/logo through this layer; Phase 10 reverted those
+# to direct filesystem access (per-pod ephemeral cache).
+BUCKET_COMPOSITES: str = "composites"

--- a/blobstore/local.py
+++ b/blobstore/local.py
@@ -1,13 +1,11 @@
-"""Local-filesystem blob store (upstream default).
+"""Local-filesystem blob store (default).
 
-Bytes for the TMDB poster cache and TMDB logo cache land under
-``/app/cache/<bucket>/<key>`` (matching upstream's two existing directories).
-Behaviour mirrors upstream's previous cache.py functions exactly — TTL via
-filesystem mtime, lazy stale-eviction on read.
+Bytes for the composite-poster cache land under
+``/app/cache/composites/<key>.jpg``. Behaviour matches the S3 backend's
+signature so the public selector can swap them transparently.
 
-I/O is wrapped in ``asyncio.to_thread`` so the event loop isn't blocked by
-disk reads on a slow volume. Same call shape as the S3 backend so the public
-selector can swap them transparently.
+I/O is wrapped in ``asyncio.to_thread`` so the event loop isn't blocked
+by disk reads on a slow volume.
 """
 import asyncio
 import logging
@@ -16,13 +14,12 @@ import time
 
 logger = logging.getLogger(__name__)
 
-from config import TMDB_POSTER_CACHE_DIR, TMDB_LOGO_CACHE_DIR
+from config import COMPOSITE_BLOB_DIR
 
 
 # Bucket → on-disk base directory.
 _BUCKETS: dict[str, str] = {
-    "tmdb-posters": TMDB_POSTER_CACHE_DIR,
-    "tmdb-logos":   TMDB_LOGO_CACHE_DIR,
+    "composites": COMPOSITE_BLOB_DIR,
 }
 
 
@@ -34,24 +31,11 @@ def _base_for(bucket: str) -> str:
 
 
 def _safe_path(base_dir: str, filename: str) -> str:
-    """Defensive: resolve symlinks and ensure the result stays inside base_dir.
-    Upstream's check verbatim."""
+    """Defensive: resolve symlinks and ensure the result stays inside base_dir."""
     path = os.path.realpath(os.path.join(base_dir, filename))
     if not path.startswith(os.path.realpath(base_dir)):
         raise ValueError(f"Path traversal attempt: {filename!r}")
     return path
-
-
-def _remove_if_dir(path: str) -> bool:
-    """Remove *path* if it is a directory (stale artefact from a previous bug)."""
-    if os.path.isdir(path):
-        try:
-            os.rmdir(path)
-            logger.info(f"Removed stale cache directory at {path}")
-        except OSError:
-            pass
-        return True
-    return False
 
 
 async def init() -> None:
@@ -71,8 +55,6 @@ def _get_sync(bucket: str, key: str, max_age_seconds: int) -> bytes | None:
     base = _base_for(bucket)
     path = _safe_path(base, key)
 
-    if _remove_if_dir(path):
-        return None
     if not os.path.exists(path):
         return None
 
@@ -97,12 +79,25 @@ def _put_sync(bucket: str, key: str, data: bytes) -> None:
     base = _base_for(bucket)
     path = _safe_path(base, key)
     try:
-        _remove_if_dir(path)
-        os.makedirs(os.path.dirname(path), exist_ok=True)
-        with open(path, "wb") as f:
+        os.makedirs(os.path.dirname(path) or base, exist_ok=True)
+        # Atomic write: temp file in same dir, then rename.
+        tmp_path = f"{path}.tmp"
+        with open(tmp_path, "wb") as f:
             f.write(data)
+        os.replace(tmp_path, path)
     except Exception as exc:
         logger.error(f"Blob cache write error for {bucket}:{key}: {exc}")
+
+
+def _delete_sync(bucket: str, key: str) -> None:
+    base = _base_for(bucket)
+    path = _safe_path(base, key)
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    except Exception as exc:
+        logger.warning(f"Blob cache delete error for {bucket}:{key}: {exc}")
 
 
 async def get(bucket: str, key: str, max_age_seconds: int) -> bytes | None:
@@ -113,6 +108,10 @@ async def put(bucket: str, key: str, data: bytes, content_type: str | None = Non
     # content_type is irrelevant for the FS backend but accepted so the
     # signature matches the S3 backend.
     await asyncio.to_thread(_put_sync, bucket, key, data)
+
+
+async def delete(bucket: str, key: str) -> None:
+    await asyncio.to_thread(_delete_sync, bucket, key)
 
 
 def url_for(bucket: str, key: str) -> str | None:

--- a/blobstore/s3.py
+++ b/blobstore/s3.py
@@ -3,21 +3,17 @@
 URL format::
 
     s3://<bucket>?endpoint=<https://...>&region=<region>&prefix=<prefix>
-    s3://<bucket>?endpoint=https://s3.us-east-005.backblazeb2.com
+    s3://postersplus-composites?endpoint=https://s3.us-west-002.backblazeb2.com&region=us-west-002
 
 Credentials come from the standard AWS env vars (AWS_ACCESS_KEY_ID,
 AWS_SECRET_ACCESS_KEY) or the IAM role the pod is running under.
 
-Bytes are stored at ``<bucket>/<prefix>/<bucket-name>/<key>`` so a single S3
-bucket can hold multiple PostersPlus buckets (tmdb-posters, tmdb-logos)
-without colliding. The prefix is also useful when several tenants share a
-bucket — `?prefix=tenant-a` keeps their keyspaces separate.
-
-TTL is enforced server-side via S3 lifecycle rules, not by this code — set
-the bucket to expire objects under each prefix at the rate that matches
-TMDB_POSTER_CACHE_DURATION / TMDB_LOGO_CACHE_DURATION. The ``get`` path
-honours the in-flight max-age check so a misconfigured bucket can't serve
-stale data either.
+Holds the composite-poster bytes. With ``OBJECT_STORE_PUBLIC_URL`` set
+(e.g. ``https://posters.postersplus.elfhosted.com`` — a Cloudflare custom
+domain in front of the same B2 bucket), the /poster endpoint can return
+a 302 to that URL on a cache hit and the app pod isn't on the read path
+at all. With Cloudflare's Bandwidth Alliance, B2→Cloudflare egress is
+free; Cloudflare→user is standard CF bandwidth.
 
 I/O uses boto3 (sync) wrapped in ``asyncio.to_thread`` so the event loop
 stays responsive on cache misses.
@@ -131,9 +127,9 @@ def _get_sync(bucket: str, key: str, max_age_seconds: int) -> bytes | None:
         if last_modified is not None:
             age = time.time() - last_modified.timestamp()
             if age > max_age_seconds:
-                # Stale — delete (best-effort) and miss. Close the body first
-                # so the underlying HTTP connection returns to the pool rather
-                # than leaking until GC.
+                # Stale — delete (best-effort) and miss. Close the body
+                # first so the underlying HTTP connection returns to the
+                # pool rather than leaking until GC.
                 try:
                     _client.delete_object(Bucket=_bucket_name, Key=obj_key)
                 except ClientError:
@@ -155,6 +151,14 @@ def _put_sync(bucket: str, key: str, data: bytes, content_type: str | None) -> N
         logger.warning(f"S3 PUT error for {obj_key}: {exc}")
 
 
+def _delete_sync(bucket: str, key: str) -> None:
+    obj_key = _object_key(bucket, key)
+    try:
+        _client.delete_object(Bucket=_bucket_name, Key=obj_key)
+    except ClientError as exc:
+        logger.warning(f"S3 DELETE error for {obj_key}: {exc}")
+
+
 async def get(bucket: str, key: str, max_age_seconds: int) -> bytes | None:
     if _client is None:
         return None
@@ -167,13 +171,19 @@ async def put(bucket: str, key: str, data: bytes, content_type: str | None = Non
     await asyncio.to_thread(_put_sync, bucket, key, data, content_type)
 
 
+async def delete(bucket: str, key: str) -> None:
+    if _client is None:
+        return
+    await asyncio.to_thread(_delete_sync, bucket, key)
+
+
 def url_for(bucket: str, key: str) -> str | None:
     """Return a public CDN URL when OBJECT_STORE_PUBLIC_URL is configured.
 
-    Used by the storage backends to optionally serve poster bytes by 302
-    redirect rather than proxying them through the app. Returns None if no
-    public URL is configured — caller should fall back to fetching the bytes
-    inline.
+    Used by the /poster endpoint to optionally serve composite bytes by
+    302 redirect rather than proxying them through the app. Returns None
+    if no public URL is configured — caller falls back to fetching the
+    bytes inline.
     """
     if not _public_url:
         return None

--- a/cache.py
+++ b/cache.py
@@ -6,10 +6,17 @@ selected via ``DATABASE_URL``. Public function names and signatures are
 preserved exactly so every ``from cache import …`` callsite works unchanged on
 either backend.
 
-Phase 6 (observability) adds thin instrumentation wrappers around the six
+Phase 6 (observability) adds thin instrumentation wrappers around the
 most-trafficked lookup functions so cache hit/miss counters show up on the
 /metrics endpoint. The wrappers are pass-throughs; backend selection stays
 in storage/__init__.py.
+
+Phase 10 split:
+  * Composite (rendered) poster bytes — async, delegate to the blobstore
+    package. Bytes live in S3 / B2 + CDN; the relational backend holds
+    only metadata rows.
+  * TMDB poster/logo bytes — sync, local filesystem only (per-pod
+    ephemeral cache in front of TMDB's own CDN).
 
 Cherry-pick guide:
   * Upstream changes to ``cache.py`` map almost 1-to-1 to
@@ -23,7 +30,6 @@ from storage import (
     prune_caches,
     ping,
     close,
-    set_cached_final_poster,
     set_cached_rating,
     set_cached_quality,
     get_cached_trending_snapshot,
@@ -37,12 +43,15 @@ from storage import (
     add_digital_releases,
 )
 from storage import (
-    get_cached_final_poster   as _raw_get_final_poster,
-    get_cached_rating         as _raw_get_rating,
-    get_cached_quality        as _raw_get_quality,
-    get_cached_tmdb_metadata  as _raw_get_tmdb_metadata,
-    get_cached_tmdb_poster    as _raw_get_tmdb_poster,
-    get_cached_tmdb_logo      as _raw_get_tmdb_logo,
+    get_cached_final_poster      as _raw_get_final_poster,
+    set_cached_final_poster      as _raw_set_final_poster,
+    get_cached_final_poster_url,
+    is_cached_final_poster_fresh as _raw_is_final_fresh,
+    get_cached_rating            as _raw_get_rating,
+    get_cached_quality           as _raw_get_quality,
+    get_cached_tmdb_metadata     as _raw_get_tmdb_metadata,
+    get_cached_tmdb_poster       as _raw_get_tmdb_poster,
+    get_cached_tmdb_logo         as _raw_get_tmdb_logo,
 )
 import metrics as _metrics
 
@@ -56,10 +65,26 @@ def _record(table: str, hit: bool) -> None:
 # Instrumented lookup wrappers. Behaviour identical to the underlying
 # storage call; only side-effect is a counter increment.
 
-def get_cached_final_poster(cache_key):
-    r = _raw_get_final_poster(cache_key)
+async def get_cached_final_poster(cache_key):
+    r = await _raw_get_final_poster(cache_key)
     _record("final_poster", r is not None)
     return r
+
+
+async def is_cached_final_poster_fresh(cache_key) -> bool:
+    """Lightweight freshness probe. Returns True if a fresh metadata
+    row exists for this cache_key (no blob fetch). Used by /poster to
+    skip the byte download when a CDN URL is available and we can 302
+    straight to the CDN."""
+    fresh = await _raw_is_final_fresh(cache_key)
+    # Same `final_poster` table for hit/miss accounting.
+    _record("final_poster", fresh)
+    return fresh
+
+
+async def set_cached_final_poster(cache_key, jpeg_bytes):
+    """Async pass-through to the storage backend's blobstore-aware writer."""
+    await _raw_set_final_poster(cache_key, jpeg_bytes)
 
 
 def get_cached_rating(imdb_id):
@@ -80,14 +105,14 @@ def get_cached_tmdb_metadata(cache_key):
     return r
 
 
-async def get_cached_tmdb_poster(cache_key):
-    r = await _raw_get_tmdb_poster(cache_key)
+def get_cached_tmdb_poster(cache_key):
+    r = _raw_get_tmdb_poster(cache_key)
     _record("tmdb_poster", r is not None)
     return r
 
 
-async def get_cached_tmdb_logo(cache_key):
-    r = await _raw_get_tmdb_logo(cache_key)
+def get_cached_tmdb_logo(cache_key):
+    r = _raw_get_tmdb_logo(cache_key)
     _record("tmdb_logo", r is not None)
     return r
 
@@ -99,6 +124,8 @@ __all__ = [
     "ping",
     "close",
     "get_cached_final_poster",
+    "get_cached_final_poster_url",
+    "is_cached_final_poster_fresh",
     "set_cached_final_poster",
     "get_cached_rating",
     "set_cached_rating",

--- a/config.py
+++ b/config.py
@@ -15,6 +15,11 @@ DB_PATH               = "/app/cache/cache.db"
 BADGE_DIR             = "/app/badges"
 TMDB_POSTER_CACHE_DIR = "/app/cache/tmdb_posters" # base posters from TMDB
 TMDB_LOGO_CACHE_DIR   = "/app/cache/tmdb_logos" # base logos from TMDB
+# Composite blob cache (Phase 10) — local backend uses this dir, S3
+# backend ignores it. Composite bytes used to live in the relational DB
+# as BYTEA; now they live here (filesystem) or in an S3 bucket when
+# OBJECT_STORE_URL is set.
+COMPOSITE_BLOB_DIR    = "/app/cache/composites"
 
 # Environment
 

--- a/main.py
+++ b/main.py
@@ -171,6 +171,8 @@ from cache import (
     get_cached_quality,
     get_cached_rating,
     get_cached_final_poster,
+    get_cached_final_poster_url,
+    is_cached_final_poster_fresh,
     set_cached_final_poster,
     init_db,
     is_digital_release,
@@ -713,7 +715,11 @@ async def _cache_prune_loop() -> None:
 
             if lease_token is not None:
                 logger.info("Running scheduled cache prune (leader)")
-                await asyncio.get_running_loop().run_in_executor(None, prune_caches)
+                # Phase 10: prune_caches is async (blobstore deletes for
+                # evicted composite rows). The DB-side work inside it still
+                # runs sync, but a 6h-cadence call to a sync sqlite path
+                # via the event loop is fine.
+                await prune_caches()
                 # Coordinator-managed state (rating backoff, bg-fetch claims).
                 # On the in-process backend this evicts expired entries from
                 # per-worker dicts; Redis backend is a no-op (server expires).
@@ -1076,10 +1082,26 @@ async def get_poster(
             "&".join(f"{k}={v}" for k, v in sorted(raw_params.items())).encode()
         ).hexdigest()[:8]
         final_cache_key = f"{imdb_id}:{type}:{_params_hash}"
-        cached_jpeg = get_cached_final_poster(final_cache_key)
-        if cached_jpeg is not None:
-            logger.info(f"Final poster cache hit for {final_cache_key}")
-            return Response(content=cached_jpeg, media_type="image/jpeg")
+        # Phase 10: when the blobstore has a public CDN URL configured
+        # (OBJECT_STORE_PUBLIC_URL), the freshness probe alone is enough
+        # to authorise a 302 — we never pull the bytes back through the
+        # app on a cache hit. With Cloudflare in front of a B2 bucket
+        # that's free egress + zero app CPU per hit.
+        cdn_url = get_cached_final_poster_url(final_cache_key)
+        if cdn_url is not None:
+            if await is_cached_final_poster_fresh(final_cache_key):
+                logger.info(f"Final poster cache hit (CDN redirect) for {final_cache_key}")
+                resp = Response(status_code=302)
+                resp.headers["Location"] = cdn_url
+                if _cfg.CDN_CACHE_TTL > 0:
+                    resp.headers["Cache-Control"] = f"public, max-age={_cfg.CDN_CACHE_TTL}"
+                return resp
+        else:
+            # Local / no-CDN deployment: fall back to inline serving.
+            cached_jpeg = await get_cached_final_poster(final_cache_key)
+            if cached_jpeg is not None:
+                logger.info(f"Final poster cache hit (inline) for {final_cache_key}")
+                return Response(content=cached_jpeg, media_type="image/jpeg")
     else:
         final_cache_key = None
 
@@ -1437,7 +1459,7 @@ async def get_poster(
         # cached composite would be missing badges.  The next request will find
         # quality cached and store a proper composite then.
         if final_cache_key is not None and not quality_pending:
-            set_cached_final_poster(final_cache_key, img_bytes)
+            await set_cached_final_poster(final_cache_key, img_bytes)
             logger.info(f"Final poster cached for {final_cache_key}")
 
         if _render_fut is not None:

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -24,6 +24,8 @@ _PUBLIC_API = (
     "ping",
     "close",
     "get_cached_final_poster",
+    "get_cached_final_poster_url",
+    "is_cached_final_poster_fresh",
     "set_cached_final_poster",
     "get_cached_rating",
     "set_cached_rating",

--- a/storage/postgres_backend.py
+++ b/storage/postgres_backend.py
@@ -4,9 +4,14 @@ Mirrors the public surface of storage.sqlite_backend so upstream's API is
 preserved exactly. Operates against a connection pool so multiple replicas /
 workers can share a single Postgres instance.
 
-TMDB poster/logo bytes are routed through the ``blobstore`` package (Phase 3),
-which selects local FS by default or S3-compatible storage when
-``OBJECT_STORE_URL`` is set.
+Phase 10 split (matches the SQLite backend):
+  * TMDB poster/logo bytes — per-pod filesystem (TMDB's own CDN is the
+    source of truth; sharing this cache across replicas is not worth
+    the complexity).
+  * Composite (rendered) bytes — delegated to the ``blobstore`` package
+    so they can land in S3 + Cloudflare instead of clogging the Postgres
+    backups / replication stream as BYTEA. This module keeps only the
+    cache metadata row.
 """
 import logging
 import os
@@ -39,32 +44,19 @@ from config import (
     DIGITAL_RELEASE_MAX_AGE_DAYS,
 )
 
-# TTL helpers are pure functions — reuse rather than duplicate.
-from storage.sqlite_backend import _rating_ttl, _quality_ttl
-
-
-_POSTER_TTL_SECONDS = TMDB_POSTER_CACHE_DURATION * 86400
-_LOGO_TTL_SECONDS   = TMDB_LOGO_CACHE_DURATION   * 86400
-
-
-# TMDB poster/logo bytes — delegated to blobstore. Identical to the SQLite
-# backend's wrappers; defined here so the Postgres backend is a self-contained
-# module with no compile-time dependency on the SQLite module's content
-# (only the pure TTL helpers above).
-async def get_cached_tmdb_poster(cache_key: str) -> bytes | None:
-    return await blobstore.get(blobstore.BUCKET_TMDB_POSTERS, cache_key, _POSTER_TTL_SECONDS)
-
-
-async def set_cached_tmdb_poster(cache_key: str, data: bytes) -> None:
-    await blobstore.put(blobstore.BUCKET_TMDB_POSTERS, cache_key, data, content_type="image/jpeg")
-
-
-async def get_cached_tmdb_logo(cache_key: str) -> bytes | None:
-    return await blobstore.get(blobstore.BUCKET_TMDB_LOGOS, cache_key, _LOGO_TTL_SECONDS)
-
-
-async def set_cached_tmdb_logo(cache_key: str, data: bytes) -> None:
-    await blobstore.put(blobstore.BUCKET_TMDB_LOGOS, cache_key, data, content_type="image/png")
+# Pure helpers (TTL math + filesystem-cache primitives) shared with the
+# SQLite backend so we don't duplicate them. These have no Postgres-side
+# state, just static functions that take a cache key.
+from storage.sqlite_backend import (
+    _rating_ttl,
+    _quality_ttl,
+    _safe_cache_path,
+    _remove_if_dir,
+    get_cached_tmdb_poster,
+    set_cached_tmdb_poster,
+    get_cached_tmdb_logo,
+    set_cached_tmdb_logo,
+)
 
 
 _pool: ConnectionPool | None = None
@@ -134,12 +126,19 @@ def _bootstrap_schema(conn) -> None:
                 original_language   TEXT
             )
         """)
+        # Phase 10: composite-poster bytes live in blobstore (FS or S3); the
+        # table holds only metadata so the relational backend can do TTL
+        # bookkeeping cheaply.
         cur.execute("""
             CREATE TABLE IF NOT EXISTS final_poster_cache (
                 cache_key  TEXT PRIMARY KEY,
-                jpeg_bytes BYTEA  NOT NULL,
                 cached_at  BIGINT NOT NULL
             )
+        """)
+        # Migrate pre-Phase-10 deployments that have the BYTEA column.
+        # Idempotent: IF EXISTS makes it a no-op on new installs.
+        cur.execute("""
+            ALTER TABLE final_poster_cache DROP COLUMN IF EXISTS jpeg_bytes
         """)
         cur.execute("""
             CREATE INDEX IF NOT EXISTS final_poster_cache_cached_at_idx
@@ -186,77 +185,132 @@ def init_db() -> None:
 # Final composite poster cache
 # ---------------------------------------------------------------------------
 
-def get_cached_final_poster(cache_key: str) -> bytes | None:
-    try:
-        with _get_pool().connection() as conn:
-            with conn.cursor() as cur:
+def _peek_final_poster(cache_key: str) -> bool:
+    """Row-only TTL check. True if a fresh row exists; deletes the row
+    on expiry. Caller handles blob cleanup."""
+    with _get_pool().connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                "SELECT cached_at FROM final_poster_cache WHERE cache_key = %s",
+                (cache_key,),
+            )
+            row = cur.fetchone()
+            if not row:
+                return False
+            (cached_at,) = row
+            age_secs = time.time() - cached_at
+            if age_secs > COMPOSITE_CACHE_TTL:
+                logger.info(f"Final poster cache expired for {cache_key} ({age_secs/86400:.1f}d old)")
                 cur.execute(
-                    "SELECT jpeg_bytes, cached_at FROM final_poster_cache WHERE cache_key = %s",
+                    "DELETE FROM final_poster_cache WHERE cache_key = %s",
                     (cache_key,),
                 )
-                row = cur.fetchone()
-                if not row:
-                    return None
-                jpeg_bytes, cached_at = row
-                age_secs = time.time() - cached_at
-                if age_secs > COMPOSITE_CACHE_TTL:
-                    logger.info(f"Final poster cache expired for {cache_key} ({age_secs/86400:.1f}d old)")
-                    cur.execute(
-                        "DELETE FROM final_poster_cache WHERE cache_key = %s",
-                        (cache_key,),
-                    )
-                    conn.commit()
-                    return None
-                return bytes(jpeg_bytes)
+                conn.commit()
+                return False
+            return True
+
+
+async def is_cached_final_poster_fresh(cache_key: str) -> bool:
+    """Lightweight freshness probe — checks the metadata row + TTL only,
+    never touches the blobstore. Lets /poster emit a 302 to the CDN
+    without pulling the bytes through the app pod."""
+    try:
+        fresh = _peek_final_poster(cache_key)
+        if not fresh:
+            await blobstore.delete(blobstore.BUCKET_COMPOSITES, cache_key)
+        return fresh
+    except Exception as exc:
+        logger.error(f"Final poster freshness probe error: {exc}")
+        return False
+
+
+async def get_cached_final_poster(cache_key: str) -> bytes | None:
+    """Full read: metadata TTL check + blob fetch. Used as the
+    inline-serve fallback when no CDN URL is configured."""
+    try:
+        if not _peek_final_poster(cache_key):
+            await blobstore.delete(blobstore.BUCKET_COMPOSITES, cache_key)
+            return None
+        return await blobstore.get(
+            blobstore.BUCKET_COMPOSITES, cache_key, max_age_seconds=COMPOSITE_CACHE_TTL,
+        )
     except Exception as exc:
         logger.error(f"Final poster cache read error: {exc}")
         return None
 
 
-def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes) -> None:
+def get_cached_final_poster_url(cache_key: str) -> str | None:
+    """Public CDN URL for the composite, or None when no URL is configured."""
+    return blobstore.url_for(blobstore.BUCKET_COMPOSITES, cache_key)
+
+
+async def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes) -> None:
     try:
+        # Write bytes first so the metadata row is never present without
+        # a backing blob.
+        await blobstore.put(
+            blobstore.BUCKET_COMPOSITES, cache_key, jpeg_bytes,
+            content_type="image/jpeg",
+        )
         with _get_pool().connection() as conn:
             with conn.cursor() as cur:
                 cur.execute(
                     """
-                    INSERT INTO final_poster_cache (cache_key, jpeg_bytes, cached_at)
-                    VALUES (%s, %s, %s)
+                    INSERT INTO final_poster_cache (cache_key, cached_at)
+                    VALUES (%s, %s)
                     ON CONFLICT (cache_key) DO UPDATE SET
-                        jpeg_bytes = EXCLUDED.jpeg_bytes,
                         cached_at  = EXCLUDED.cached_at
                     """,
-                    (cache_key, jpeg_bytes, int(time.time())),
+                    (cache_key, int(time.time())),
                 )
+                evict_keys: list[str] = []
                 if COMPOSITE_MAX_ENTRIES > 0:
                     cur.execute("SELECT COUNT(*) FROM final_poster_cache")
                     (count,) = cur.fetchone()
                     overflow = count - COMPOSITE_MAX_ENTRIES
                     if overflow > 0:
                         cur.execute(
-                            """
-                            DELETE FROM final_poster_cache WHERE cache_key IN (
-                                SELECT cache_key FROM final_poster_cache
-                                ORDER BY cached_at ASC LIMIT %s
-                            )
-                            """,
+                            "SELECT cache_key FROM final_poster_cache "
+                            "ORDER BY cached_at ASC LIMIT %s",
                             (overflow,),
+                        )
+                        evict_keys = [r[0] for r in cur.fetchall()]
+                        cur.execute(
+                            """
+                            DELETE FROM final_poster_cache WHERE cache_key = ANY(%s)
+                            """,
+                            (evict_keys,),
                         )
                         logger.info(f"Composite cache cap: evicted {overflow} oldest entries")
             conn.commit()
+        # Best-effort blob cleanup for evicted keys, outside the pool ctx.
+        for k in evict_keys:
+            try:
+                await blobstore.delete(blobstore.BUCKET_COMPOSITES, k)
+            except Exception:
+                pass
     except Exception as exc:
         logger.error(f"Final poster cache write error: {exc}")
 
 
-def prune_caches() -> None:
+async def prune_caches() -> None:
     now = int(time.time())
+    expired_composite_keys: list[str] = []
     try:
         with _get_pool().connection() as conn:
             with conn.cursor() as cur:
+                # Phase 10: capture composite keys before deletion so we can
+                # drop the corresponding blobs after the txn commits.
                 cur.execute(
-                    "DELETE FROM final_poster_cache WHERE cached_at < %s",
+                    "SELECT cache_key FROM final_poster_cache WHERE cached_at < %s",
                     (now - COMPOSITE_CACHE_TTL,),
                 )
-                if cur.rowcount:
+                expired_composite_keys = [r[0] for r in cur.fetchall()]
+                if expired_composite_keys:
+                    cur.execute(
+                        "DELETE FROM final_poster_cache WHERE cache_key = ANY(%s)",
+                        (expired_composite_keys,),
+                    )
                     logger.info(f"Pruned {cur.rowcount} expired composite cache entries")
 
                 rating_cutoff   = now - OLD_CACHE_DURATION           * 86400
@@ -291,6 +345,15 @@ def prune_caches() -> None:
                     logger.info(f"Pruned {cur.rowcount} expired digital release cache entries")
             conn.commit()
         # Postgres autovacuum handles space reclamation — no explicit VACUUM here.
+
+        # Phase 10: best-effort blob deletion for evicted composite rows,
+        # outside the connection-pool ctx so a slow S3 doesn't hold the
+        # connection.
+        for k in expired_composite_keys:
+            try:
+                await blobstore.delete(blobstore.BUCKET_COMPOSITES, k)
+            except Exception as exc:
+                logger.warning(f"Composite blob delete error for {k}: {exc}")
     except Exception as exc:
         logger.error(f"Cache prune error: {exc}")
 

--- a/storage/sqlite_backend.py
+++ b/storage/sqlite_backend.py
@@ -3,10 +3,14 @@
 Default backend, used when DATABASE_URL is unset. Kept close to upstream's
 cache.py so cherry-picks from upstream apply with minimal friction.
 
-The TMDB poster/logo *bytes* are no longer handled here — Phase 3 moved them
-behind the ``blobstore`` package so they can be opt-in routed to S3. The
-poster/logo *cache functions* (get_cached_tmdb_poster etc.) remain as async
-wrappers that delegate to blobstore, preserving the public cache API.
+Phase 10 split:
+  * TMDB poster/logo bytes  — direct filesystem (per-pod ephemeral cache
+    in front of TMDB's own CDN; no remote-shared storage benefit since
+    TMDB's CDN is the source of truth).
+  * Composite (rendered) bytes — delegated to the blobstore package
+    so they can live in S3 + a CDN custom domain instead of bloating
+    the relational backend with BYTEA. This module keeps only the
+    cache metadata row (cache_key + cached_at).
 """
 import logging
 import os
@@ -131,13 +135,47 @@ def init_db() -> None:
         )
     """)
 
+    # Phase 10: composite-poster bytes live in blobstore (FS or S3); the
+    # table holds only metadata so the relational backend can do TTL
+    # bookkeeping cheaply. New deployments get the metadata-only schema;
+    # existing deployments need the migration below.
     _db_conn.execute("""
         CREATE TABLE IF NOT EXISTS final_poster_cache (
             cache_key  TEXT PRIMARY KEY,
-            jpeg_bytes BLOB    NOT NULL,
             cached_at  INTEGER NOT NULL
         )
     """)
+    # Migrate the pre-Phase-10 schema if present. SQLite 3.35+ supports
+    # DROP COLUMN; existing bytes are discarded (cache refills via TTL).
+    existing_composite_cols = {
+        row[1]
+        for row in _db_conn.execute("PRAGMA table_info(final_poster_cache)").fetchall()
+    }
+    if "jpeg_bytes" in existing_composite_cols:
+        try:
+            _db_conn.execute("ALTER TABLE final_poster_cache DROP COLUMN jpeg_bytes")
+            logger.info(
+                "Migrated final_poster_cache: dropped jpeg_bytes BLOB; "
+                "cached composites will re-render on next request"
+            )
+        except sqlite3.OperationalError as exc:
+            # SQLite < 3.35: rebuild the table without the column.
+            logger.info(
+                "SQLite DROP COLUMN unsupported (%s); recreating final_poster_cache "
+                "without jpeg_bytes (existing cached composites discarded)", exc,
+            )
+            _db_conn.execute("ALTER TABLE final_poster_cache RENAME TO _final_poster_cache_old")
+            _db_conn.execute("""
+                CREATE TABLE final_poster_cache (
+                    cache_key TEXT PRIMARY KEY,
+                    cached_at INTEGER NOT NULL
+                )
+            """)
+            _db_conn.execute("""
+                INSERT INTO final_poster_cache (cache_key, cached_at)
+                SELECT cache_key, cached_at FROM _final_poster_cache_old
+            """)
+            _db_conn.execute("DROP TABLE _final_poster_cache_old")
 
     _db_conn.execute("""
         CREATE TABLE IF NOT EXISTS digital_release_cache (
@@ -187,39 +225,91 @@ def _quality_ttl(release_date: str | None) -> int:
         return QUALITY_OLD_CACHE_DURATION
 
 
-def get_cached_final_poster(cache_key: str) -> bytes | None:
+def _peek_final_poster(cache_key: str) -> bool:
+    """Internal: row-only TTL check. Returns True if a fresh row exists.
+
+    Used by both the cheap freshness probe (CDN-redirect path) and the
+    full bytes fetcher. Side-effect: deletes the row on expiry, schedules
+    the blob deletion via the caller's async context.
+    """
+    row = get_db().execute(
+        "SELECT cached_at FROM final_poster_cache WHERE cache_key = ?",
+        (cache_key,),
+    ).fetchone()
+    if not row:
+        return False
+    (cached_at,) = row
+    age_secs = time.time() - cached_at
+    if age_secs > COMPOSITE_CACHE_TTL:
+        logger.info(f"Final poster cache expired for {cache_key} ({age_secs/86400:.1f}d old)")
+        with _db_lock:
+            get_db().execute(
+                "DELETE FROM final_poster_cache WHERE cache_key = ?", (cache_key,)
+            )
+            get_db().commit()
+        return False
+    return True
+
+
+async def is_cached_final_poster_fresh(cache_key: str) -> bool:
+    """Lightweight freshness probe — checks the metadata row + TTL only,
+    never touches the blobstore. Used by /poster to decide whether to
+    emit a 302 to the CDN without pulling the bytes through the app
+    pod.
+
+    On expiry: deletes both the metadata row and the orphaned blob.
+    """
     try:
-        row = get_db().execute(
-            "SELECT jpeg_bytes, cached_at FROM final_poster_cache WHERE cache_key = ?",
-            (cache_key,),
-        ).fetchone()
-        if not row:
+        fresh = _peek_final_poster(cache_key)
+        if not fresh:
+            # Best-effort blob cleanup. Safe no-op when no blob exists.
+            await blobstore.delete(blobstore.BUCKET_COMPOSITES, cache_key)
+        return fresh
+    except Exception as exc:
+        logger.error(f"Final poster freshness probe error: {exc}")
+        return False
+
+
+async def get_cached_final_poster(cache_key: str) -> bytes | None:
+    """Full read: metadata TTL check + blob fetch. Use the freshness
+    probe + url_for + 302 path instead when a CDN URL is configured;
+    this function is only the inline-serve fallback."""
+    try:
+        if not _peek_final_poster(cache_key):
+            await blobstore.delete(blobstore.BUCKET_COMPOSITES, cache_key)
             return None
-        jpeg_bytes, cached_at = row
-        age_secs = time.time() - cached_at
-        if age_secs > COMPOSITE_CACHE_TTL:
-            logger.info(f"Final poster cache expired for {cache_key} ({age_secs/86400:.1f}d old)")
-            with _db_lock:
-                get_db().execute(
-                    "DELETE FROM final_poster_cache WHERE cache_key = ?", (cache_key,)
-                )
-                get_db().commit()
-            return None
-        return bytes(jpeg_bytes)
+        return await blobstore.get(
+            blobstore.BUCKET_COMPOSITES, cache_key, max_age_seconds=COMPOSITE_CACHE_TTL,
+        )
     except Exception as exc:
         logger.error(f"Final poster cache read error: {exc}")
         return None
 
 
-def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes) -> None:
+def get_cached_final_poster_url(cache_key: str) -> str | None:
+    """Return a public CDN URL for the composite if the blobstore backend
+    provides one (OBJECT_STORE_PUBLIC_URL set). Sync — doesn't touch S3,
+    just constructs the URL from the configured prefix. Caller still
+    needs to confirm the row exists + isn't expired before redirecting."""
+    return blobstore.url_for(blobstore.BUCKET_COMPOSITES, cache_key)
+
+
+async def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes) -> None:
     try:
+        # Write the bytes first so the metadata row is never present
+        # without a corresponding blob (which would race a reader into
+        # a 502-ish state on the very first hit).
+        await blobstore.put(
+            blobstore.BUCKET_COMPOSITES, cache_key, jpeg_bytes,
+            content_type="image/jpeg",
+        )
         with _db_lock:
             get_db().execute(
                 """
-                INSERT OR REPLACE INTO final_poster_cache (cache_key, jpeg_bytes, cached_at)
-                VALUES (?, ?, ?)
+                INSERT OR REPLACE INTO final_poster_cache (cache_key, cached_at)
+                VALUES (?, ?)
                 """,
-                (cache_key, jpeg_bytes, int(time.time())),
+                (cache_key, int(time.time())),
             )
             if COMPOSITE_MAX_ENTRIES > 0:
                 (count,) = get_db().execute(
@@ -227,29 +317,52 @@ def set_cached_final_poster(cache_key: str, jpeg_bytes: bytes) -> None:
                 ).fetchone()
                 overflow = count - COMPOSITE_MAX_ENTRIES
                 if overflow > 0:
+                    evict = get_db().execute(
+                        "SELECT cache_key FROM final_poster_cache "
+                        "ORDER BY cached_at ASC LIMIT ?",
+                        (overflow,),
+                    ).fetchall()
+                    evict_keys = [r[0] for r in evict]
                     get_db().execute(
                         "DELETE FROM final_poster_cache WHERE cache_key IN "
-                        "(SELECT cache_key FROM final_poster_cache "
-                        " ORDER BY cached_at ASC LIMIT ?)",
-                        (overflow,),
+                        f"({','.join('?' * len(evict_keys))})",
+                        evict_keys,
                     )
                     logger.info(f"Composite cache cap: evicted {overflow} oldest entries")
+                    # Best-effort blob cleanup for evicted keys.
+                    for k in evict_keys:
+                        try:
+                            await blobstore.delete(blobstore.BUCKET_COMPOSITES, k)
+                        except Exception:
+                            pass
             get_db().commit()
     except Exception as exc:
         logger.error(f"Final poster cache write error: {exc}")
 
 
-def prune_caches() -> None:
+async def prune_caches() -> None:
     now = int(time.time())
     try:
+        expired_composite_keys: list[str] = []
         with _db_lock:
             db = get_db()
 
-            r = db.execute(
-                "DELETE FROM final_poster_cache WHERE cached_at < ?",
-                (now - COMPOSITE_CACHE_TTL,),
-            )
-            if r.rowcount:
+            # Phase 10: collect the composite cache_keys before deletion so
+            # we can drop the corresponding blobs. Without this the metadata
+            # row goes away but the S3/B2 object lingers forever.
+            cutoff = now - COMPOSITE_CACHE_TTL
+            expired_composite_keys = [
+                r[0] for r in db.execute(
+                    "SELECT cache_key FROM final_poster_cache WHERE cached_at < ?",
+                    (cutoff,),
+                ).fetchall()
+            ]
+            if expired_composite_keys:
+                placeholders = ",".join("?" * len(expired_composite_keys))
+                r = db.execute(
+                    f"DELETE FROM final_poster_cache WHERE cache_key IN ({placeholders})",
+                    expired_composite_keys,
+                )
                 logger.info(f"Pruned {r.rowcount} expired composite cache entries")
 
             rating_cutoff   = now - OLD_CACHE_DURATION           * 86400
@@ -286,6 +399,15 @@ def prune_caches() -> None:
         with _db_lock:
             get_db().execute("PRAGMA incremental_vacuum(100)")
             get_db().commit()
+
+        # Phase 10: best-effort blob deletion for the composite rows we
+        # just evicted. Done outside the db lock + after commit so a
+        # slow S3 doesn't hold up the write lock.
+        for k in expired_composite_keys:
+            try:
+                await blobstore.delete(blobstore.BUCKET_COMPOSITES, k)
+            except Exception as exc:
+                logger.warning(f"Composite blob delete error for {k}: {exc}")
 
     except Exception as exc:
         logger.error(f"Cache prune error: {exc}")
@@ -491,31 +613,106 @@ def set_cached_trending_snapshot(
 
 
 # ---------------------------------------------------------------------------
-# TMDB poster/logo bytes — delegated to the blobstore (Phase 3).
+# TMDB poster/logo cache — local filesystem, per-pod ephemeral.
 #
-# Filesystem behaviour for these is preserved by the default LocalBlobStore;
-# the S3 backend is opt-in via OBJECT_STORE_URL. These functions are async so
-# both backends share one call shape; callers in tmdb.py await them.
+# Phase 10: reverted from blobstore delegation. TMDB's own CDN is the
+# source of truth; this cache is just a latency-optimisation in front of
+# image.tmdb.org. Sharing it across replicas via S3 buys very little and
+# complicates the data path. On pod restart the cache re-warms in the
+# first few minutes of traffic.
+#
+# Synchronous (matching upstream's shape) so cherry-picks from upstream's
+# cache.py apply with minimal churn.
 # ---------------------------------------------------------------------------
 
-_POSTER_TTL_SECONDS = TMDB_POSTER_CACHE_DURATION * 86400
-_LOGO_TTL_SECONDS   = TMDB_LOGO_CACHE_DURATION   * 86400
+def _safe_cache_path(base_dir: str, filename: str) -> str:
+    path = os.path.realpath(os.path.join(base_dir, filename))
+    if not path.startswith(os.path.realpath(base_dir)):
+        raise ValueError(f"Path traversal attempt: {filename!r}")
+    return path
 
 
-async def get_cached_tmdb_poster(cache_key: str) -> bytes | None:
-    return await blobstore.get(blobstore.BUCKET_TMDB_POSTERS, cache_key, _POSTER_TTL_SECONDS)
+def _remove_if_dir(path: str) -> bool:
+    """Remove *path* if it is a directory (stale artefact from a previous bug)."""
+    if os.path.isdir(path):
+        try:
+            os.rmdir(path)
+            logger.info(f"Removed stale cache directory at {path}")
+        except OSError:
+            pass
+        return True
+    return False
 
 
-async def set_cached_tmdb_poster(cache_key: str, data: bytes) -> None:
-    await blobstore.put(blobstore.BUCKET_TMDB_POSTERS, cache_key, data, content_type="image/jpeg")
+def get_cached_tmdb_poster(cache_key: str) -> bytes | None:
+    path = _safe_cache_path(TMDB_POSTER_CACHE_DIR, cache_key)
+
+    if not os.path.exists(path):
+        return None
+
+    age_days = (time.time() - os.path.getmtime(path)) / 86400
+
+    if age_days > TMDB_POSTER_CACHE_DURATION:
+        logger.info(f"TMDB poster cache expired for {cache_key}")
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        return None
+
+    try:
+        with open(path, "rb") as f:
+            return f.read()
+    except Exception as exc:
+        logger.error(f"TMDB poster cache read error: {exc}")
+        return None
 
 
-async def get_cached_tmdb_logo(cache_key: str) -> bytes | None:
-    return await blobstore.get(blobstore.BUCKET_TMDB_LOGOS, cache_key, _LOGO_TTL_SECONDS)
+def set_cached_tmdb_poster(cache_key: str, data: bytes) -> None:
+    try:
+        path = _safe_cache_path(TMDB_POSTER_CACHE_DIR, cache_key)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "wb") as f:
+            f.write(data)
+    except Exception as exc:
+        logger.error(f"TMDB poster cache write error: {exc}")
 
 
-async def set_cached_tmdb_logo(cache_key: str, data: bytes) -> None:
-    await blobstore.put(blobstore.BUCKET_TMDB_LOGOS, cache_key, data, content_type="image/png")
+def get_cached_tmdb_logo(cache_key: str) -> bytes | None:
+    path = _safe_cache_path(TMDB_LOGO_CACHE_DIR, cache_key)
+
+    if _remove_if_dir(path):
+        return None
+
+    if not os.path.exists(path):
+        return None
+
+    age_days = (time.time() - os.path.getmtime(path)) / 86400
+
+    if age_days > TMDB_LOGO_CACHE_DURATION:
+        logger.info(f"TMDB logo cache expired for {cache_key}")
+        try:
+            os.remove(path)
+        except FileNotFoundError:
+            pass
+        return None
+
+    try:
+        with open(path, "rb") as f:
+            return f.read()
+    except Exception as exc:
+        logger.error(f"TMDB logo cache read error: {exc}")
+        return None
+
+
+def set_cached_tmdb_logo(cache_key: str, data: bytes) -> None:
+    try:
+        path = _safe_cache_path(TMDB_LOGO_CACHE_DIR, cache_key)
+        _remove_if_dir(path)
+        with open(path, "wb") as f:
+            f.write(data)
+    except Exception as exc:
+        logger.error(f"TMDB logo cache write error: {exc}")
 
 
 def get_cached_tmdb_metadata(cache_key: str) -> dict | None:

--- a/tmdb.py
+++ b/tmdb.py
@@ -211,7 +211,7 @@ async def fetch_poster_image(
     alpha_composite throughout without mode-checking.
     """
     poster_cache_key = f"{media_type}_{tmdb_id}_{poster_path.strip('/')}"
-    cached_bytes = await get_cached_tmdb_poster(poster_cache_key)
+    cached_bytes = get_cached_tmdb_poster(poster_cache_key)
 
     if cached_bytes:
         logger.info(f"TMDB poster cache hit for {tmdb_id}")
@@ -230,7 +230,7 @@ async def fetch_poster_image(
     # Save as JPEG RGB (no alpha needed for base poster; restoring alpha on load is free)
     buf = io.BytesIO()
     image.convert("RGB").save(buf, format="JPEG", quality=92)
-    await set_cached_tmdb_poster(poster_cache_key, buf.getvalue())
+    set_cached_tmdb_poster(poster_cache_key, buf.getvalue())
 
     return image
 
@@ -273,7 +273,7 @@ async def fetch_logo(
     logo_path = candidates[0]["file_path"]
 
     logo_cache_key = logo_path.strip('/').replace('/', '_')
-    cached_bytes = await get_cached_tmdb_logo(logo_cache_key)
+    cached_bytes = get_cached_tmdb_logo(logo_cache_key)
 
     if cached_bytes:
         logger.info("TMDB logo cache hit")
@@ -294,7 +294,7 @@ async def fetch_logo(
 
     buf = io.BytesIO()
     logo.save(buf, format="PNG")
-    await set_cached_tmdb_logo(logo_cache_key, buf.getvalue())
+    set_cached_tmdb_logo(logo_cache_key, buf.getvalue())
 
     return logo
 


### PR DESCRIPTION
Phase 10. Moves composite (rendered) poster bytes from BYTEA in the relational backend into the blobstore (S3/B2 + Cloudflare). TMDB poster/logo bytes reverted to per-pod filesystem cache. See RESILIENCE.md for full notes. Codex review: 2 P2 findings, both fixed.