### PR TITLE
Phase 11 — anonymous CDN-cacheable preset endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,9 @@ env/
 # Docker runtime cache volume
 postersplus-cache/
 
+# Local dev runner output (run-local.py writes SQLite, blobs, prom state here)
+.local-cache/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/RESILIENCE.md
+++ b/RESILIENCE.md
@@ -668,3 +668,36 @@ Plus two follow-ups raised in the final pass and fixed pre-clean-review:
 - **Preview disabled after importing a /p URL.** `loadPreview` and `queuePreviewReload` required `resolvedTmdbId`, but preset URLs only carry imdb_id. **Fixed:** preset mode requires only `resolvedImdbId`; the server-side resolver handles the rest.
 
 Phase 11 ready to merge once user signs and commits.
+
+### Phase 11 — public-tier UX lock (follow-up)
+
+User direction: "public users should be able to hit `/` without a 403, but only be able to pick a preset — everything else that changes the rendered poster must be locked." The original Phase 11 model required `ACCESS_KEY` to be unset on public hosts; the follow-up makes the configurator anonymous-friendly while preserving the security boundary at `/poster`.
+
+**Backend changes:**
+
+- `/`, `/server-caps`, `/search`, `/resolve-imdb` — drop the unconditional `access_key` gate.
+- `/server-caps` — returns `access_key_required` (whether the operator has `ACCESS_KEY` set) and `access_key_valid` (whether the supplied key matches), so the UI can tell when to enter preset-only mode.
+- `/poster` — gate unchanged. The real security boundary doesn't move.
+- `/search` + `/resolve-imdb` — conditional gating: anonymous only when `PRESET_ENABLED=true` (the public preset flow needs the title picker). Instances with `ACCESS_KEY` set but presets disabled keep the original access_key gate so the operator's server TMDB key isn't exposed to a deployment with no anonymous user-facing flow.
+- New `ANONYMOUS_TMDB_RPS` config (default 5/s) — independent of `RATE_LIMIT_RPS`. Anonymous `/search`/`/resolve-imdb` traffic uses a shared "anonymous" bucket sized by this floor so an operator who didn't set `RATE_LIMIT_RPS` doesn't accidentally leak unthrottled access to the server TMDB quota. Authenticated callers (valid `access_key`, or caller-supplied `tmdb_key`) get per-tenant buckets sized by `RATE_LIMIT_RPS` instead — they're not subject to the anonymous floor.
+
+**Frontend changes (`configurator.html`):**
+
+- New "Public access — preset selection only" banner with an unlock input. The banner is shown only when `body.preset-only-mode` is active (i.e. server requires key AND we don't have a valid one).
+- `body.preset-only-mode` CSS: dims and pointer-disables every section after Core Config (rating, sash, logo, badges, weights) plus the TMDB/MDBlist/language fields inside Core Config. Search box + preset dropdown stay editable.
+- `body.preset-only-mode` hides the URL-import row entirely — importing a `/poster` URL into lock mode would silently drop its params.
+- `applyLockMode()` toggles the body class on every `/server-caps` response, hides the "Custom" preset option when locked (only when presets are enabled), and forces `default` as the active preset to bootstrap a usable URL.
+- `onAccessKeyInput()` syncs the visible unlock input → hidden `cfg-access-key`, persists to localStorage, debounces a fresh `/server-caps?access_key=...` fetch. Status indicator in the banner shows `LOCKED` / `INVALID` / `UNLOCKED`.
+- `resetDefaults()` re-applies the lock at the end so a click of Reset on a locked instance can't escape preset mode by reverting `cfg-preset` to the (hidden) Custom option.
+
+**Codex review pass count:** 6 iterations to clean. Findings + fixes:
+
+1. **[P1] Anonymous TMDB proxies had no rate-limit.** `/search` and `/resolve-imdb` ran unauthenticated against the server TMDB key with no throttle when `RATE_LIMIT_RPS=0` (the default). **Fixed:** new `ANONYMOUS_TMDB_RPS` floor (default 5/s), independent of `RATE_LIMIT_RPS`.
+2. **[P2] Forced preset when presets disabled.** `applyLockMode` set the preset to `default` even on instances with `PRESET_ENABLED=false`, generating `/p/default/...` URLs that 404'd. **Fixed:** preset is only forced when `serverCaps.preset_enabled` is true.
+3. **[P1] /search + /resolve-imdb anonymous even when presets disabled.** No reason for these to be public on a non-preset deployment. **Fixed:** new `_gate_anonymous_tmdb_proxy()` keeps the access_key requirement when `PRESET_ENABLED=false`.
+4. **[P3] Stale Prometheus state across local runs.** `run-local.py` reused `.local-cache/prom` without clearing old `*.db` files. **Fixed:** mirrors the container entrypoint's wipe-on-startup behaviour.
+5. **[P2] Authenticated tenant put in anonymous bucket.** A tenant supplying `access_key` but relying on the server's TMDB key was rate-limited at 5/s (anonymous floor) instead of `RATE_LIMIT_RPS`. **Fixed:** rate-limit helper now keys per-access_key when a valid key is supplied — only purely anonymous traffic uses the floor.
+6. **[P2] Reset bypassed lock.** `resetDefaults()` flipped `cfg-preset` to the hidden Custom option, then Copy URL emitted `/poster?...` until next `/server-caps` fetch. **Fixed:** `resetDefaults()` re-applies `applyLockMode()` before rebuilding the URL.
+7. **[P3] `.local-cache/` not gitignored.** **Fixed:** added entry to `.gitignore`.
+
+Final pass clean. Phase 11 follow-up ready to merge.

--- a/RESILIENCE.md
+++ b/RESILIENCE.md
@@ -701,3 +701,36 @@ User direction: "public users should be able to hit `/` without a 403, but only 
 7. **[P3] `.local-cache/` not gitignored.** **Fixed:** added entry to `.gitignore`.
 
 Final pass clean. Phase 11 follow-up ready to merge.
+
+### Phase 11 — informational lock banner (re-design)
+
+User direction: drop the access-key unlock UI entirely. "Users wanting more customizability can get a private instance (link to elfhosted store) or self-host (link to upstream github)." The public instance is the public instance — there's no "key escape" UX path.
+
+**Deployment model now baked in:**
+
+- Public-tier instance: `PRESET_ENABLED=true` + `ACCESS_KEY=…`. Configurator is always preset-only; lock banner shows two CTAs. /poster requires the operator's access_key — anonymous custom rendering is impossible.
+- Private-tier instance: `PRESET_ENABLED=false`. Configurator is full-featured. Access via `?access_key=…` URL when the operator gates it, open otherwise.
+- Misconfigured (`PRESET_ENABLED=true` + `ACCESS_KEY` unset): UI locks (correct), and /poster also locks (newly enforced) so the policy and the UI don't drift. Only /p/{preset}/… serves traffic.
+
+**Code changes:**
+
+- Lock banner: replaced the access-key input + status indicator with two CTAs — "Get a private instance" → `store.elfhosted.com`, "Self-host" → `github.com/UmbraProjects/PostersPlus`. CSS adds `.lock-banner-cta` and `.lock-banner-cta-row` styles.
+- `applyLockMode()`: lock condition is now `preset_enabled && !access_key_valid`. The URL-param escape hatch (`/?access_key=…`) still works for legacy tenant tooling but isn't surfaced in the UI.
+- `onAccessKeyInput()` and the `cfg-access-key-input` visible field deleted.
+- `/server-caps`: `access_key_valid` is `true` only when ACCESS_KEY is configured AND the supplied key matches. When ACCESS_KEY is unset there's no escape hatch on offer, so we report `false` to keep preset-only mode pinned.
+- `/`: conditionally anonymous — public-tier instances (`PRESET_ENABLED=true`) serve the configurator HTML to anyone; private-tier instances with `ACCESS_KEY` set keep the original access_key gate so users land on a 403 unless they reach the page via `?access_key=…`.
+- `/poster`: gate widened to fire when *either* `PRESET_ENABLED` or `ACCESS_KEY` is set, with a valid access_key as the only pass condition. Closes the loophole where `PRESET_ENABLED=true` + `ACCESS_KEY` unset would lock the UI but leave /poster wide open.
+
+**Codex review:** five iterations to clean.
+
+1. **[P1] Unlock path removed entirely.** Tenants on a preset-enabled instance arriving with `?access_key=…` were forced into preset-only mode because the lock depended only on `preset_enabled`. **Fixed:** lock condition is `preset_enabled && !access_key_valid`; the URL-param escape hatch is preserved as a legacy mechanism.
+
+2. **[P1] Preset-enabled without ACCESS_KEY left the UI unlocked.** `/server-caps` reported `access_key_valid=true` (no key configured → "valid" trivially) so the lock never engaged. **Fixed:** `access_key_valid` requires both a configured ACCESS_KEY and a matching supplied key — a missing server key gives `false`, keeping the lock on.
+
+3. **[P2] Anonymous `/` exposed access-key-protected private instances.** A fresh user on a key-gated private instance couldn't search or preview because the visible input was gone. **Fixed:** `/` is anonymous only when `PRESET_ENABLED=true`; private instances keep the original `?access_key=` gate at /.
+
+4. **[P2] UI advertised a lock that backend didn't enforce.** `PRESET_ENABLED=true` + `ACCESS_KEY` unset gave a locked UI but an open /poster. **Fixed:** /poster gate widened to fire whenever `PRESET_ENABLED` is true, requiring a valid access_key as the only pass — when ACCESS_KEY is unset there's no key that can pass and /poster is effectively disabled (only /p works).
+
+5. **Pass 5 clean.**
+
+Re-design ready to merge.

--- a/RESILIENCE.md
+++ b/RESILIENCE.md
@@ -496,6 +496,85 @@ TMDB CDN (image.tmdb.org)
 
 ---
 
+## Phase 11 — Public preset endpoint
+
+**Branch:** `phase-11-presets`
+**Status:** implementation complete, codex review pending
+
+**Motivation:** Phase 10 made the composite-poster cache cheap to serve at the edge — a single 302 redirects clients to a CDN-fronted blob. But the existing `/poster` URL is still parameterised by a long query string (every visual knob in the configurator). That's:
+
+- **Long and ugly** for share/embed scenarios.
+- **Coupled to per-user keys** (`tmdb_key`, `mdblist_key`, `access_key` are all query params), so an anonymous URL can't reuse the operator's cache hits.
+- **Cache-unfriendly at the URL level** — a CDN in front of PostersPlus would key on the full query string, fragmenting the cache.
+
+The preset endpoint solves these for the **anonymous public tier** of the service while leaving `/poster` exactly as it is for paying tenants who want full per-user customisation.
+
+**URL shape:** `GET /p/{preset}/{type}/{imdb_id}.jpg`
+
+- `preset` — one of the six registered names (see below); resolves to a fixed `raw_params` dict.
+- `type` — `movie` or `tv`. The configurator's `series` alias is folded to `tv` on this route.
+- `imdb_id` — the universal Stremio identifier (`tt\d+`). Server-side resolved to `tmdb_id` via a one-shot TMDB `/find` call, then cached forever in `imdb_to_tmdb_cache` (these mappings don't move).
+
+The path-only URL is human-shareable, deterministic, and CDN-friendly: Cloudflare in front of PostersPlus can cache `/p/awards/movie/tt0111161.jpg` directly without fragmenting on query strings.
+
+**Six starter presets** (`presets.py`):
+
+| Name         | Look                                                        |
+| ------------ | ----------------------------------------------------------- |
+| `default`    | Standard configurator-equivalent rendering                  |
+| `awards`     | Sash-forward, numeric score hidden                          |
+| `minimalist` | Small genre text, no score bar                              |
+| `letterboxd` | Numeric score + Letterboxd-weighted rating, no sash         |
+| `cinephile`  | Prestige-leaning sash priority (festival before commercial) |
+| `quality`    | Score visible + cached quality badges                       |
+
+All presets share a public-tier base: `badge_display_mode=1` (cached badges only, never AIOStreams fan-out on anonymous traffic) and `show_award_sash=true`.
+
+**Public-tier render path simplifications** (relative to `/poster`):
+
+- No `access_key` gating — endpoint is anonymous; gated only by the operator setting `PRESET_ENABLED=true`.
+- No per-user `tmdb_key` / `mdblist_key` — operator's server keys are required (the endpoint returns 503 if the server TMDB key is unconfigured).
+- No MDBlist fan-out: rating data is used only if already cached. An uncached title renders without rating once with a short `Cache-Control: max-age=300`, so the next /poster call (paid tenant) or sister /p hit can pick up warmed data after PRESET_CDN_CACHE_TTL. Prevents anonymous /p traffic from burning the operator's MDBlist quota.
+- No AIOStreams background fetch: quality tokens are read from cache; `badge_display_mode=1` means cached-or-nothing.
+- No per-tenant rate limit — all anonymous /p traffic shares the `"preset"` bucket so a runaway integration can't drag /poster down.
+
+Cache key shape is identical to `/poster`'s (`imdb_id:type:params_hash`), so a preset URL and a config-equivalent `/poster` URL hit the **same** composite blob — no duplication in storage.
+
+**Code changes:**
+
+- `presets.py` — new module; pure data. Six preset dicts + `get_preset()` / `preset_names()` accessors. Adding/renaming a preset is a one-file change.
+- `tmdb.py` — adds `resolve_imdb_to_tmdb()` (TMDB `/find` with imdb_id external source, cached).
+- `storage/{sqlite,postgres}_backend.py` — adds `imdb_to_tmdb_cache` table + get/set helpers. No TTL: the mapping is permanent.
+- `storage/__init__.py`, `cache.py` — re-export the two new helpers.
+- `config.py` — `PRESET_ENABLED` (default false) and `PRESET_CDN_CACHE_TTL` (default 86400 = 24h).
+- `main.py` — new `@app.get("/p/{preset}/{type}/{imdb_id}.jpg")` handler (~150 lines). Reuses the same coalescing dict (`_render_inflight`), render semaphore, blobstore + final-cache helpers. `/server-caps` now advertises `preset_enabled` + the list of presets.
+- `configurator.html` — preset dropdown in Core Config; when set, the URL output switches to `/p/{preset}/{type}/{imdb_id}.jpg` form. Import flow recognises and round-trips preset URLs.
+
+**Operator switches:**
+
+- `PRESET_ENABLED=true` — turn on the endpoint. Default off so private/self-hosted deployments aren't surprised.
+- `PRESET_CDN_CACHE_TTL=86400` — `Cache-Control: max-age` on successful preset responses. Long by design: presets are deterministic per (preset, type, imdb_id).
+- The operator's `SERVER_TMDB_KEY` must be set; `SERVER_MDBLIST_KEY` is optional (without it /p renders without rating data).
+
+**Verified end-to-end:**
+
+- syntax: all modified Python files parse; HTML/JS in configurator.html parses via Node `Function`.
+- preset URL → 200 jpeg (cached rating)
+- preset URL → 200 jpeg + short cache-control (uncached rating, no MDBlist key)
+- preset URL → 302 redirect to CDN bucket when `OBJECT_STORE_PUBLIC_URL` is set
+- unknown preset → 404 with explicit `Unknown preset 'foo'` detail
+- `PRESET_ENABLED=false` → 404 (endpoint hidden)
+- configurator import of preset URL round-trips back to the same preset
+- configurator import of /poster URL unchanged
+
+**Known follow-ups:**
+
+- Could pre-warm the preset cache with popular titles (Cannes Palme d'Or list, AFI 100, current Trending) so the very first anonymous hit is already CDN-cached. Cron job that POSTs against `/p/{preset}/...` for a curated list nightly.
+- Could expose `postersplus_preset_requests_total{preset, type, outcome}` metric so dashboards can see which presets are popular.
+- Trakt OAuth + watch-progress overlay (BetterPosters parity gap) would be its own per-user feature on `/poster`, not a public preset — different security model.
+
+---
+
 ## Codex review log
 
 Per-phase second opinion via `~/.claude/bin/codex-review`. Findings recorded inline below.
@@ -567,4 +646,25 @@ Self-audit notes (not findings, just explicit rationales for future readers):
 
 Phase 2 ready to merge once user signs and commits.
 
-...
+### Phase 11 — reviewed
+
+Codex review (2026-05-26): five P2 findings landed across four review iterations; all fixed. Pass 5 returned clean ("No discrete, actionable bugs were identified … internally consistent.").
+
+Findings + fixes:
+
+1. **Coalesced no-rating renders inherited the long preset TTL.** The leader correctly used `max-age=300` when no rating was cached, but waiters on `_render_inflight` returned the same bytes with `_preset_cache_header()` (24h). A concurrent caller could cache an incomplete poster at the CDN for the full preset TTL. **Fixed:** `cached_rating` (and `cached_quality`) are read *before* the coalesce decision. Coalescing is registered only on the `will_persist` path; incomplete renders bypass `_render_inflight` so each request is responsible for its own short-TTL response.
+
+2. **`series` placeholder rejected by `/p` route.** Configurator template URLs emit `{type}` literally; downstream substitutors fill that with `series` for TV shows. The /p path validator only accepted `movie|tv`, so copied preset URLs 404'd for series. **Fixed:** /p now folds `series → tv` at the top of the handler before validation.
+
+3. **Stale-when-cached-empty for quality.** `get_cached_quality(imdb_id, rel) or []` conflated `None` (cache miss) with `[]` (queried, no tokens available). Titles with a legitimately-empty cached quality row would never persist their composite. **Fixed:** `quality_missing` is now `cached_quality is None` only; an empty cached list is treated as a valid input.
+
+4. **`cfg-preset` not cleared on /poster import.** Importing a `/poster?...` URL left a previously-selected preset in the dropdown, so `build()` re-emitted `/p/{preset}/...` and the imported custom params were silently dropped. **Fixed:** the /poster import path now resets `cfg-preset` to "" and refreshes UI state before populating fields.
+
+5. **Configurator exposed preset selector when backend has `PRESET_ENABLED=false`.** Users could pick a preset and generate URLs that would 404. **Fixed:** `/server-caps` now reports `preset_enabled` + the preset name list; `updateKeyBadges()` hides the preset field on instances that haven't opted in, and clears any stale selection.
+
+Plus two follow-ups raised in the final pass and fixed pre-clean-review:
+
+- **Cache-buster broke path-only preset URLs.** `loadPreview()` appended `&_ts=...` unconditionally, producing `/p/.../tt0.jpg&_ts=...` which doesn't match the FastAPI route. **Fixed:** uses `?_ts=` when no query string is present, `&_ts=` otherwise.
+- **Preview disabled after importing a /p URL.** `loadPreview` and `queuePreviewReload` required `resolvedTmdbId`, but preset URLs only carry imdb_id. **Fixed:** preset mode requires only `resolvedImdbId`; the server-side resolver handles the rest.
+
+Phase 11 ready to merge once user signs and commits.

--- a/cache.py
+++ b/cache.py
@@ -41,6 +41,8 @@ from storage import (
     is_digital_release,
     count_digital_releases,
     add_digital_releases,
+    get_cached_imdb_to_tmdb,
+    set_cached_imdb_to_tmdb,
 )
 from storage import (
     get_cached_final_poster      as _raw_get_final_poster,

--- a/config.py
+++ b/config.py
@@ -106,6 +106,16 @@ CDN_CACHE_TTL         = int(os.environ.get("CDN_CACHE_TTL", "0"))
 PRESET_ENABLED        = os.environ.get("PRESET_ENABLED", "").strip().lower() in ("1", "true", "yes")
 PRESET_CDN_CACHE_TTL  = int(os.environ.get("PRESET_CDN_CACHE_TTL", "86400"))
 
+# Floor on anonymous /search and /resolve-imdb requests. These endpoints
+# became anonymous in the Phase 11 follow-up so the public preset flow
+# can use the title picker. RATE_LIMIT_RPS (default 0 = disabled) only
+# gates /poster + /p; without this independent floor, an operator who
+# never set RATE_LIMIT_RPS would leave the TMDB proxy endpoints
+# completely unthrottled and let any visitor burn the server TMDB quota.
+# Set to 0 to disable (e.g. for fully private deployments where the
+# configurator and proxies are already on an authenticated network).
+ANONYMOUS_TMDB_RPS    = int(os.environ.get("ANONYMOUS_TMDB_RPS", "5"))
+
 # Feature Defaults 
 
 SHOW_RATING_DISPLAY_MODE = 1

--- a/config.py
+++ b/config.py
@@ -96,6 +96,16 @@ RATE_LIMIT_RPS          = int(os.environ.get("RATE_LIMIT_RPS", "0"))
 # edge. Set to 0 to disable (e.g. when running without a CDN).
 CDN_CACHE_TTL         = int(os.environ.get("CDN_CACHE_TTL", "0"))
 
+# Phase 11: public preset endpoint (/p/{preset}/{type}/{imdb_id}.jpg).
+# When PRESET_ENABLED is true, anonymous requests can hit a small set of
+# named visual presets without supplying access_key / tmdb_key / mdblist_key.
+# The operator's server-configured keys are used; PRESET_CDN_CACHE_TTL
+# controls the Cache-Control max-age on preset responses (defaults to 1
+# day — much longer than CDN_CACHE_TTL since presets are deterministic
+# per (preset, type, imdb_id) and don't change with query params).
+PRESET_ENABLED        = os.environ.get("PRESET_ENABLED", "").strip().lower() in ("1", "true", "yes")
+PRESET_CDN_CACHE_TTL  = int(os.environ.get("PRESET_CDN_CACHE_TTL", "86400"))
+
 # Feature Defaults 
 
 SHOW_RATING_DISPLAY_MODE = 1

--- a/configurator.html
+++ b/configurator.html
@@ -945,16 +945,22 @@
   .url-param-val { color: var(--silver); }
   .url-placeholder { color: var(--gold-dim); }
 
-  /* ── PRESET-ONLY LOCK ── */
+  /* ── PRESET-ONLY LOCK ── horizontal banner between header + layout */
   .lock-banner {
     display: none;
-    margin: 14px 16px 18px;
-    padding: 14px 16px;
+    margin: 0 0 20px;
+    padding: 12px 18px;
     background: var(--black);
     border: 1px solid var(--gold-dim);
     border-left: 3px solid var(--gold);
+    gap: 18px;
+    align-items: center;
   }
-  body.preset-only-mode .lock-banner { display: block; }
+  body.preset-only-mode .lock-banner { display: flex; }
+  .lock-banner-text {
+    flex: 1 1 0;
+    min-width: 240px;
+  }
   .lock-banner-title {
     font-family: var(--mono);
     font-size: 9px;
@@ -962,27 +968,25 @@
     letter-spacing: 0.28em;
     text-transform: uppercase;
     color: var(--gold);
-    margin-bottom: 8px;
+    margin-bottom: 4px;
   }
   .lock-banner-body {
     font-family: var(--mono);
     font-size: 10px;
-    line-height: 1.55;
+    line-height: 1.5;
     color: var(--silver-dim);
-    margin-bottom: 12px;
   }
   .lock-banner-cta-row {
     display: flex;
     gap: 8px;
-    flex-wrap: wrap;
+    flex: 0 0 auto;
   }
   .lock-banner-cta {
-    flex: 1 1 0;
-    min-width: 130px;
+    min-width: 150px;
     display: flex;
     flex-direction: column;
     gap: 2px;
-    padding: 9px 12px;
+    padding: 8px 12px;
     background: var(--black2);
     border: 1px solid var(--border);
     text-decoration: none;
@@ -1014,15 +1018,16 @@
     color: var(--silver-dim);
   }
   .lock-banner-explore {
-    margin-top: 14px;
-    padding-top: 12px;
-    border-top: 1px dashed var(--border);
-    text-align: center;
+    flex: 0 0 auto;
+    padding-left: 16px;
+    border-left: 1px dashed var(--border);
+    max-width: 200px;
   }
   .lock-banner-explore-link {
     font-family: var(--mono);
     font-size: 10px;
-    letter-spacing: 0.1em;
+    line-height: 1.4;
+    letter-spacing: 0.08em;
     color: var(--silver-dim);
     text-decoration: none;
     transition: color 0.15s;
@@ -1033,6 +1038,14 @@
   }
   .lock-banner-explore-link:hover { color: var(--silver); }
   .lock-banner-explore-link:hover strong { color: var(--gold-bright); }
+  /* Narrow screens: stack the banner sections vertically so nothing
+     overflows. Mirrors the existing header mobile breakpoint. */
+  @media (max-width: 860px) {
+    body.preset-only-mode .lock-banner { flex-direction: column; align-items: stretch; }
+    .lock-banner-explore { padding-left: 0; border-left: none; padding-top: 10px; border-top: 1px dashed var(--border); max-width: none; text-align: center; }
+    .lock-banner-cta-row { flex-wrap: wrap; }
+    .lock-banner-cta { flex: 1 1 0; }
+  }
 
   /* Anything below Core Config (i.e. the visual configuration sections)
      is locked out when preset-only-mode is active. The user can still
@@ -1362,6 +1375,47 @@
     </a>
   </header>
 
+  <!-- Public-tier informational banner (Phase 11 follow-up). Sits in the
+       full-width slot between the header and the two-column layout so
+       it doesn't burn vertical real estate inside the left panel. The
+       JS toggles body.preset-only-mode and the banner switches from
+       display:none to display:flex. Tenants who want custom rendering
+       run a private instance (separate URL); there's no unlock UI here. -->
+  <div class="lock-banner" id="lock-banner">
+    <div class="lock-banner-text">
+      <div class="lock-banner-title">Public access — preset selection only</div>
+      <div class="lock-banner-body">
+        To keep the public instance scalable, customization is limited
+        to the presets. For full control, run your own instance:
+      </div>
+    </div>
+    <div class="lock-banner-cta-row">
+      <a class="lock-banner-cta primary"
+         href="https://store.elfhosted.com?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_store"
+         target="_blank" rel="noopener noreferrer">
+        <span class="lock-banner-cta-label">Get a private instance</span>
+        <span class="lock-banner-cta-sub">elfhosted.com — managed</span>
+      </a>
+      <a class="lock-banner-cta"
+         href="https://github.com/UmbraProjects/PostersPlus"
+         target="_blank" rel="noopener noreferrer">
+        <span class="lock-banner-cta-label">Self-host</span>
+        <span class="lock-banner-cta-sub">github.com — upstream source</span>
+      </a>
+    </div>
+    <!-- Stremio addons guide CTA. Anchor text deliberately uses the
+         exact "best Stremio addons" phrase for SEO weight on the
+         target page. UTM-tagged so the guide can attribute referrals
+         back to which PostersPlus surface drove the click. -->
+    <div class="lock-banner-explore">
+      <a class="lock-banner-explore-link"
+         href="https://stremio-addons-guide.elfhosted.com/?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_addons_guide"
+         target="_blank" rel="noopener noreferrer">
+        Explore more — the <strong>best Stremio addons</strong>, hosted &amp; reviewed &rarr;
+      </a>
+    </div>
+  </div>
+
   <div class="main-layout">
 
     <!-- LEFT: CONFIG PANEL -->
@@ -1375,47 +1429,6 @@
 
         <input type="hidden" id="cfg-domain" value="">
         <input type="hidden" id="cfg-access-key" value="">
-
-        <!-- Public-tier informational banner (Phase 11 follow-up).
-             Shown whenever /server-caps reports preset_enabled=true —
-             the public-tier marker. Tenants who want custom rendering
-             run a private instance (separate URL); they never need to
-             "unlock" the public configurator with a key, so there's no
-             input here. Two CTAs explain how to get one. -->
-        <div class="lock-banner" id="lock-banner">
-          <div class="lock-banner-title">Public access — preset selection only</div>
-          <div class="lock-banner-body">
-            To keep the public instance scalable, customization is limited
-            to the presets below. For full per-poster control (sliders,
-            weights, sash priority), run your own instance:
-          </div>
-          <div class="lock-banner-cta-row">
-            <a class="lock-banner-cta primary"
-               href="https://store.elfhosted.com?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_store"
-               target="_blank" rel="noopener noreferrer">
-              <span class="lock-banner-cta-label">Get a private instance</span>
-              <span class="lock-banner-cta-sub">elfhosted.com — managed</span>
-            </a>
-            <a class="lock-banner-cta"
-               href="https://github.com/UmbraProjects/PostersPlus"
-               target="_blank" rel="noopener noreferrer">
-              <span class="lock-banner-cta-label">Self-host</span>
-              <span class="lock-banner-cta-sub">github.com — upstream source</span>
-            </a>
-          </div>
-          <!-- Stremio addons guide CTA. Anchor text deliberately uses the
-               exact "best Stremio addons" phrase for SEO weight on the
-               target page (it's the canonical landing page for that
-               keyword). UTM-tagged so the guide can attribute referrals
-               back to which PostersPlus surface drove the click. -->
-          <div class="lock-banner-explore">
-            <a class="lock-banner-explore-link"
-               href="https://stremio-addons-guide.elfhosted.com/?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_addons_guide"
-               target="_blank" rel="noopener noreferrer">
-              Explore more — the <strong>best Stremio addons</strong>, hosted &amp; reviewed &rarr;
-            </a>
-          </div>
-        </div>
 
         <!-- 1. CORE CONFIG -->
         <div class="section">

--- a/configurator.html
+++ b/configurator.html
@@ -945,22 +945,20 @@
   .url-param-val { color: var(--silver); }
   .url-placeholder { color: var(--gold-dim); }
 
-  /* ── PRESET-ONLY LOCK ── horizontal banner between header + layout */
+  /* ── PRESET-ONLY LOCK ── horizontal banner between header + layout.
+     Text on top, three CTAs on a single row below — keeps the banner
+     short while letting all three calls-to-action breathe equally. */
   .lock-banner {
     display: none;
+    flex-direction: column;
+    gap: 10px;
     margin: 0 0 20px;
     padding: 12px 18px;
     background: var(--black);
     border: 1px solid var(--gold-dim);
     border-left: 3px solid var(--gold);
-    gap: 18px;
-    align-items: center;
   }
   body.preset-only-mode .lock-banner { display: flex; }
-  .lock-banner-text {
-    flex: 1 1 0;
-    min-width: 240px;
-  }
   .lock-banner-title {
     font-family: var(--mono);
     font-size: 9px;
@@ -979,10 +977,11 @@
   .lock-banner-cta-row {
     display: flex;
     gap: 8px;
-    flex: 0 0 auto;
+    flex-wrap: wrap;
   }
   .lock-banner-cta {
-    min-width: 150px;
+    flex: 1 1 0;
+    min-width: 160px;
     display: flex;
     flex-direction: column;
     gap: 2px;
@@ -996,12 +995,9 @@
     background: #161616;
     border-color: var(--gold-dim);
   }
-  .lock-banner-cta.primary {
-    border-color: var(--gold-dim);
-  }
-  .lock-banner-cta.primary:hover {
-    border-color: var(--gold);
-  }
+  .lock-banner-cta.primary  { border-color: var(--gold-dim); }
+  .lock-banner-cta.primary:hover { border-color: var(--gold); }
+  .lock-banner-cta.tertiary { border-style: dashed; }
   .lock-banner-cta-label {
     font-family: var(--mono);
     font-size: 10px;
@@ -1016,35 +1012,6 @@
     letter-spacing: 0.16em;
     text-transform: uppercase;
     color: var(--silver-dim);
-  }
-  .lock-banner-explore {
-    flex: 0 0 auto;
-    padding-left: 16px;
-    border-left: 1px dashed var(--border);
-    max-width: 200px;
-  }
-  .lock-banner-explore-link {
-    font-family: var(--mono);
-    font-size: 10px;
-    line-height: 1.4;
-    letter-spacing: 0.08em;
-    color: var(--silver-dim);
-    text-decoration: none;
-    transition: color 0.15s;
-  }
-  .lock-banner-explore-link strong {
-    color: var(--gold);
-    font-weight: 500;
-  }
-  .lock-banner-explore-link:hover { color: var(--silver); }
-  .lock-banner-explore-link:hover strong { color: var(--gold-bright); }
-  /* Narrow screens: stack the banner sections vertically so nothing
-     overflows. Mirrors the existing header mobile breakpoint. */
-  @media (max-width: 860px) {
-    body.preset-only-mode .lock-banner { flex-direction: column; align-items: stretch; }
-    .lock-banner-explore { padding-left: 0; border-left: none; padding-top: 10px; border-top: 1px dashed var(--border); max-width: none; text-align: center; }
-    .lock-banner-cta-row { flex-wrap: wrap; }
-    .lock-banner-cta { flex: 1 1 0; }
   }
 
   /* Anything below Core Config (i.e. the visual configuration sections)
@@ -1402,16 +1369,15 @@
         <span class="lock-banner-cta-label">Self-host</span>
         <span class="lock-banner-cta-sub">github.com — upstream source</span>
       </a>
-    </div>
-    <!-- Stremio addons guide CTA. Anchor text deliberately uses the
-         exact "best Stremio addons" phrase for SEO weight on the
-         target page. UTM-tagged so the guide can attribute referrals
-         back to which PostersPlus surface drove the click. -->
-    <div class="lock-banner-explore">
-      <a class="lock-banner-explore-link"
+      <!-- Stremio addons guide CTA. Anchor text deliberately uses the
+           exact "best Stremio addons" phrase for SEO weight on the
+           target page. UTM-tagged so the guide can attribute referrals
+           back to which PostersPlus surface drove the click. -->
+      <a class="lock-banner-cta tertiary"
          href="https://stremio-addons-guide.elfhosted.com/?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_addons_guide"
          target="_blank" rel="noopener noreferrer">
-        Explore more — the <strong>best Stremio addons</strong>, hosted &amp; reviewed &rarr;
+        <span class="lock-banner-cta-label">Best Stremio addons</span>
+        <span class="lock-banner-cta-sub">curated guide — hosted &amp; reviewed</span>
       </a>
     </div>
   </div>

--- a/configurator.html
+++ b/configurator.html
@@ -940,6 +940,89 @@
   .url-param-val { color: var(--silver); }
   .url-placeholder { color: var(--gold-dim); }
 
+  /* ── PRESET-ONLY LOCK ── */
+  .lock-banner {
+    display: none;
+    margin: 14px 16px 18px;
+    padding: 14px 16px;
+    background: var(--black);
+    border: 1px solid var(--gold-dim);
+    border-left: 3px solid var(--gold);
+  }
+  body.preset-only-mode .lock-banner { display: block; }
+  .lock-banner-title {
+    font-family: var(--mono);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--gold);
+    margin-bottom: 8px;
+  }
+  .lock-banner-body {
+    font-family: var(--mono);
+    font-size: 10px;
+    line-height: 1.55;
+    color: var(--silver-dim);
+    margin-bottom: 12px;
+  }
+  .lock-banner-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .lock-banner-row input {
+    flex: 1;
+    padding: 7px 10px;
+    background: var(--black2);
+    border: 1px solid var(--border);
+    color: var(--silver);
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.05em;
+  }
+  .lock-banner-status {
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    min-width: 70px;
+    text-align: right;
+  }
+  .lock-banner-status.ok    { color: #6cd084; }
+  .lock-banner-status.err   { color: #d06c6c; }
+  .lock-banner-status.info  { color: var(--silver-dim); }
+
+  /* Anything below Core Config (i.e. the visual configuration sections)
+     is locked out when preset-only-mode is active. The user can still
+     SEE the sections but can't interact with them — a discoverability
+     win for tenants ("look what you get with a key") at zero cost. */
+  body.preset-only-mode .section ~ .section .section-body,
+  body.preset-only-mode .section ~ .section .section-header {
+    opacity: 0.35;
+    pointer-events: none;
+    user-select: none;
+  }
+  /* Inside Core Config: lock the per-user knobs (TMDB / MDBlist keys and
+     language) but keep search + preset dropdown editable. */
+  body.preset-only-mode #cfg-tmdb-key,
+  body.preset-only-mode #cfg-mdblist-key,
+  body.preset-only-mode #cfg-language {
+    opacity: 0.4;
+    pointer-events: none;
+  }
+  body.preset-only-mode #cfg-tmdb-key + .field-hint,
+  body.preset-only-mode #cfg-mdblist-key + .field-hint {
+    opacity: 0.4;
+  }
+  /* Hide the URL import row entirely in lock mode — importing a /poster
+     URL would silently drop its params, and a preset URL doesn't need
+     the import box (the dropdown does the same job in one click). */
+  body.preset-only-mode #import-input,
+  body.preset-only-mode #import-row,
+  body.preset-only-mode .import-modal,
+  body.preset-only-mode .import-toggle { display: none !important; }
+
   /* ── BUTTONS ── */
   .btn-row {
     display: flex;
@@ -1251,6 +1334,30 @@
 
         <input type="hidden" id="cfg-domain" value="">
         <input type="hidden" id="cfg-access-key" value="">
+
+        <!-- Preset-only lock banner (Phase 11 follow-up). Shown only when
+             /server-caps reports access_key_required=true and the supplied
+             key is missing/invalid. Anonymous public visitors land here:
+             they can pick a preset (the only emitted URL form is the
+             anonymous /p/...) but every control that drives /poster
+             output is dimmed and pointer-disabled via .preset-only-mode.
+             Tenants paste their access key into the unlock input; the JS
+             re-validates against /server-caps and removes the body class. -->
+        <div class="lock-banner" id="lock-banner">
+          <div class="lock-banner-title">Public access — preset selection only</div>
+          <div class="lock-banner-body">
+            Pick a preset below to generate a shareable poster URL. Custom
+            rendering (sliders, weights, sash priority) is reserved for
+            tenants. Paste your access key to unlock.
+          </div>
+          <div class="lock-banner-row">
+            <input type="text" id="cfg-access-key-input"
+                   placeholder="access key"
+                   autocomplete="off" spellcheck="false"
+                   oninput="onAccessKeyInput()">
+            <span class="lock-banner-status" id="lock-banner-status"></span>
+          </div>
+        </div>
 
         <!-- 1. CORE CONFIG -->
         <div class="section">
@@ -1669,6 +1776,10 @@ const qs = new URLSearchParams(window.location.search);
   const ak = qs.get('access_key') || localStorage.getItem('postersplus_access_key') || '';
   document.getElementById('cfg-access-key').value = ak;
   if (ak) localStorage.setItem('postersplus_access_key', ak);
+  // Mirror into the lock-banner visible input so tenants returning from
+  // a previous session see their key already populated.
+  const visible = document.getElementById('cfg-access-key-input');
+  if (visible && ak) visible.value = ak;
 })();
 
 const MOVIE_SOURCES = ['letterboxd','trakt','tomatoes','popcorn','imdb','metacritic','metacriticuser','tmdb','rogerebert','myanimelist'];
@@ -1704,7 +1815,7 @@ const SASH_SLOTS = [
 let sashOrder    = SASH_SLOTS.map(s => s.id);
 let sashDisabled = new Set();   // IDs explicitly disabled via ✕ button
 let mediaType = 'movie', resolvedImdbId = '', resolvedTmdbId = '';
-let serverCaps = { tmdb_key_set: false, mdblist_key_set: false, aiostreams_configured: false, preset_enabled: false, presets: [] };
+let serverCaps = { tmdb_key_set: false, mdblist_key_set: false, aiostreams_configured: false, preset_enabled: false, presets: [], access_key_required: false, access_key_valid: true };
 let searchDebounce = null, previewDebounce = null, previewLoading = false, imdbResolvePending = false;
 
 const previewPanel = document.querySelector('.preview-panel');
@@ -1841,6 +1952,71 @@ function updateKeyBadges() {
       }
     }
   }
+
+  // Phase 11 follow-up: preset-only-mode is the public-host posture.
+  // When the server has ACCESS_KEY set and we don't have a valid one,
+  // every /poster-driving control is dimmed via body.preset-only-mode
+  // and the "Custom" option is removed from the preset dropdown so the
+  // only emittable URL form is the anonymous /p/{preset}/.... A tenant
+  // with a key types it into the lock banner and the body class drops.
+  applyLockMode();
+}
+
+function applyLockMode() {
+  const lock = serverCaps.access_key_required && !serverCaps.access_key_valid;
+  document.body.classList.toggle('preset-only-mode', lock);
+
+  // The "Custom" option in the preset dropdown is option index 0
+  // (value=""). When locked AND presets are enabled, hide it so users
+  // can't pick a setting that would emit a /poster URL with
+  // default-but-invisible params. When presets are NOT enabled, leave
+  // it alone — forcing "default" while the backend serves 404 on /p
+  // routes is worse UX than the visible lock banner alone.
+  const presetField = document.getElementById('cfg-preset');
+  if (presetField && serverCaps.preset_enabled) {
+    const customOpt = presetField.querySelector('option[value=""]');
+    if (customOpt) customOpt.hidden = lock;
+    if (lock && (!presetField.value || presetField.value === '')) {
+      presetField.value = 'default';
+      refreshPresetUiState();
+      build();
+    }
+  }
+
+  // Lock-banner status indicator.
+  const statusEl = document.getElementById('lock-banner-status');
+  if (statusEl) {
+    if (!serverCaps.access_key_required) {
+      statusEl.textContent = '';
+      statusEl.className = 'lock-banner-status';
+    } else if (serverCaps.access_key_valid) {
+      statusEl.textContent = 'UNLOCKED';
+      statusEl.className = 'lock-banner-status ok';
+    } else if (vEl('cfg-access-key')) {
+      statusEl.textContent = 'INVALID';
+      statusEl.className = 'lock-banner-status err';
+    } else {
+      statusEl.textContent = 'LOCKED';
+      statusEl.className = 'lock-banner-status info';
+    }
+  }
+}
+
+// Debounced re-validation when the user types into the lock-banner input.
+let _accessKeyDebounce = null;
+function onAccessKeyInput() {
+  const visible = document.getElementById('cfg-access-key-input');
+  const hidden  = document.getElementById('cfg-access-key');
+  if (!visible || !hidden) return;
+  const value = visible.value.trim();
+  hidden.value = value;
+  // Persist so a page reload doesn't re-lock a tenant who's already
+  // entered their key. localStorage was already the canonical storage
+  // for cfg-access-key in the upstream flow.
+  if (value) localStorage.setItem('postersplus_access_key', value);
+  else       localStorage.removeItem('postersplus_access_key');
+  clearTimeout(_accessKeyDebounce);
+  _accessKeyDebounce = setTimeout(() => { fetchServerCaps(); }, 250);
 }
 
 function updateBadgeModeHint() {
@@ -2467,6 +2643,11 @@ function resetDefaults() {
   localStorage.removeItem('postersplus_sash_order');
   buildSashList();
   refreshPresetUiState();
+  // Re-apply preset-only lock if active. resetDefaults() flipped
+  // cfg-preset back to the default-selected Custom option ("") which
+  // would otherwise emit a /poster URL — locked anonymous users
+  // must stay on a preset.
+  applyLockMode();
   build();
   collapsePreview();
   setLog('preview-log', 'Reset to defaults. API keys preserved.', 'info');

--- a/configurator.html
+++ b/configurator.html
@@ -127,7 +127,12 @@
     color: inherit;
   }
   .header-right:hover .hosted-by-brand { color: var(--gold-bright); }
-  .header-right svg { display: block; }
+  .header-right .hosted-by-logo {
+    display: block;
+    width: 36px;
+    height: 36px;
+    flex: 0 0 auto;
+  }
   .hosted-by-label {
     font-family: var(--mono);
     font-size: 9px;
@@ -1317,18 +1322,16 @@
       </div>
     </div>
 
-    <!-- ElfHosted brand block — replace the inline <svg> below with the
-         real ElfHosted logo when you have it. Keeping it inline (rather
-         than referencing /static/) so the configurator stays a single
-         self-contained file. -->
+    <!-- ElfHosted brand block. Logo is referenced by URL (rather than
+         inlined) because the canonical SVG ships ~39KB of Inkscape
+         metadata. Loading it from docs.elfhosted.com keeps the
+         configurator HTML small and lets the asset evolve without a
+         redeploy here. -->
     <a class="header-right" href="https://elfhosted.com" target="_blank" rel="noopener noreferrer">
-      <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
-        <!-- placeholder mark: stylised "elf hat" silhouette. Swap for the
-             real logo SVG when ready. -->
-        <path d="M18 4 L8 26 L28 26 Z" stroke="#c9a14a" stroke-width="1.4" fill="none"/>
-        <circle cx="18" cy="30" r="2" fill="#e6c068"/>
-        <path d="M14 26 H22" stroke="#c9a14a" stroke-width="1.4" stroke-linecap="round"/>
-      </svg>
+      <img class="hosted-by-logo"
+           src="https://docs.elfhosted.com/images/logo.svg"
+           alt="ElfHosted"
+           width="36" height="36">
       <div>
         <div class="hosted-by-label">Hosted by</div>
         <div class="hosted-by-brand">ElfHosted</div>

--- a/configurator.html
+++ b/configurator.html
@@ -1897,8 +1897,16 @@ async function fetchServerCaps() {
     const resp = await fetch(url);
     if (!resp.ok) return;
     serverCaps = await resp.json();
-    updateKeyBadges();
-  } catch(e) {}
+  } catch(e) {
+    console.warn('fetchServerCaps failed', e);
+    return;
+  }
+  // Apply the lock state first — independent of badge/hint DOM elements
+  // that may or may not be present in this fork's configurator HTML. A
+  // null-deref inside updateKeyBadges() must not strand the lock in the
+  // unlocked state.
+  try { applyLockMode(); }   catch(e) { console.warn('applyLockMode failed', e); }
+  try { updateKeyBadges(); } catch(e) { console.warn('updateKeyBadges failed', e); }
 }
 
 function updateKeyBadges() {
@@ -1909,22 +1917,26 @@ function updateKeyBadges() {
   const tmdbInput = document.getElementById('cfg-tmdb-key');
   const mdbInput  = document.getElementById('cfg-mdblist-key');
 
+  // These badge/hint elements are upstream-historical and not guaranteed
+  // to exist in every configurator variant — guard each access so a
+  // missing badge node can't strand the rest of the function (notably
+  // the preset-only lock flow downstream).
   if (serverCaps.tmdb_key_set) {
-    tmdbBadge.style.display = ''; tmdbBadge.textContent = 'Server Key Set'; tmdbBadge.className = 'server-key-badge';
-    tmdbHint.style.display = ''; tmdbHint.textContent = 'Server-side TMDB key configured. Your key (if entered) takes priority.';
-    tmdbInput.placeholder = 'Optional — server key used if blank';
+    if (tmdbBadge) { tmdbBadge.style.display = ''; tmdbBadge.textContent = 'Server Key Set'; tmdbBadge.className = 'server-key-badge'; }
+    if (tmdbHint)  { tmdbHint.style.display = '';  tmdbHint.textContent = 'Server-side TMDB key configured. Your key (if entered) takes priority.'; }
+    if (tmdbInput) tmdbInput.placeholder = 'Optional — server key used if blank';
   } else {
-    tmdbBadge.style.display = ''; tmdbBadge.textContent = 'No Server Key'; tmdbBadge.className = 'server-key-badge missing';
-    tmdbHint.style.display = 'none';
-    tmdbInput.placeholder = 'Required — no server key configured';
+    if (tmdbBadge) { tmdbBadge.style.display = ''; tmdbBadge.textContent = 'No Server Key'; tmdbBadge.className = 'server-key-badge missing'; }
+    if (tmdbHint)  tmdbHint.style.display = 'none';
+    if (tmdbInput) tmdbInput.placeholder = 'Required — no server key configured';
   }
 
   if (serverCaps.mdblist_key_set) {
-    mdbHint.style.display = ''; mdbHint.textContent = 'Server-side MDblist key configured. Your key (if entered) takes priority.';
-    mdbInput.placeholder = 'Optional — server key used if blank';
+    if (mdbHint)  { mdbHint.style.display = ''; mdbHint.textContent = 'Server-side MDblist key configured. Your key (if entered) takes priority.'; }
+    if (mdbInput) mdbInput.placeholder = 'Optional — server key used if blank';
   } else {
-    mdbHint.style.display = ''; mdbHint.textContent = 'Cached titles work without a key. Uncached titles require a key.';
-    mdbInput.placeholder = 'Required for uncached titles';
+    if (mdbHint)  { mdbHint.style.display = ''; mdbHint.textContent = 'Cached titles work without a key. Uncached titles require a key.'; }
+    if (mdbInput) mdbInput.placeholder = 'Required for uncached titles';
   }
 
   const aiosHint = document.getElementById('aiostreams-hint');
@@ -1953,13 +1965,8 @@ function updateKeyBadges() {
     }
   }
 
-  // Phase 11 follow-up: preset-only-mode is the public-host posture.
-  // When the server has ACCESS_KEY set and we don't have a valid one,
-  // every /poster-driving control is dimmed via body.preset-only-mode
-  // and the "Custom" option is removed from the preset dropdown so the
-  // only emittable URL form is the anonymous /p/{preset}/.... A tenant
-  // with a key types it into the lock banner and the body class drops.
-  applyLockMode();
+  // Note: applyLockMode() is called from fetchServerCaps() directly so
+  // a missing badge/hint element above can't keep the lock from firing.
 }
 
 function applyLockMode() {

--- a/configurator.html
+++ b/configurator.html
@@ -1516,7 +1516,7 @@
          href="https://store.elfhosted.com?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_store"
          target="_blank" rel="noopener noreferrer">
         <span class="lock-banner-cta-label">Get a private instance</span>
-        <span class="lock-banner-cta-sub">elfhosted.com — managed</span>
+        <span class="lock-banner-cta-sub">$1 trial</span>
       </a>
       <a class="lock-banner-cta"
          href="https://github.com/UmbraProjects/PostersPlus"
@@ -1532,7 +1532,7 @@
          href="https://stremio-addons-guide.elfhosted.com/?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_addons_guide"
          target="_blank" rel="noopener noreferrer">
         <span class="lock-banner-cta-label">Best Stremio addons</span>
-        <span class="lock-banner-cta-sub">curated guide — hosted &amp; reviewed</span>
+        <span class="lock-banner-cta-sub">curated, opinionated guide</span>
       </a>
     </div>
   </div>

--- a/configurator.html
+++ b/configurator.html
@@ -966,32 +966,48 @@
     color: var(--silver-dim);
     margin-bottom: 12px;
   }
-  .lock-banner-row {
+  .lock-banner-cta-row {
     display: flex;
-    align-items: center;
-    gap: 10px;
+    gap: 8px;
+    flex-wrap: wrap;
   }
-  .lock-banner-row input {
-    flex: 1;
-    padding: 7px 10px;
+  .lock-banner-cta {
+    flex: 1 1 0;
+    min-width: 130px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    padding: 9px 12px;
     background: var(--black2);
     border: 1px solid var(--border);
-    color: var(--silver);
+    text-decoration: none;
+    transition: border-color 0.15s, background 0.15s;
+  }
+  .lock-banner-cta:hover {
+    background: #161616;
+    border-color: var(--gold-dim);
+  }
+  .lock-banner-cta.primary {
+    border-color: var(--gold-dim);
+  }
+  .lock-banner-cta.primary:hover {
+    border-color: var(--gold);
+  }
+  .lock-banner-cta-label {
     font-family: var(--mono);
     font-size: 10px;
-    letter-spacing: 0.05em;
-  }
-  .lock-banner-status {
-    font-family: var(--mono);
-    font-size: 9px;
-    letter-spacing: 0.2em;
+    font-weight: 600;
+    letter-spacing: 0.18em;
     text-transform: uppercase;
-    min-width: 70px;
-    text-align: right;
+    color: var(--gold);
   }
-  .lock-banner-status.ok    { color: #6cd084; }
-  .lock-banner-status.err   { color: #d06c6c; }
-  .lock-banner-status.info  { color: var(--silver-dim); }
+  .lock-banner-cta-sub {
+    font-family: var(--mono);
+    font-size: 8px;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    color: var(--silver-dim);
+  }
 
   /* Anything below Core Config (i.e. the visual configuration sections)
      is locked out when preset-only-mode is active. The user can still
@@ -1335,27 +1351,32 @@
         <input type="hidden" id="cfg-domain" value="">
         <input type="hidden" id="cfg-access-key" value="">
 
-        <!-- Preset-only lock banner (Phase 11 follow-up). Shown only when
-             /server-caps reports access_key_required=true and the supplied
-             key is missing/invalid. Anonymous public visitors land here:
-             they can pick a preset (the only emitted URL form is the
-             anonymous /p/...) but every control that drives /poster
-             output is dimmed and pointer-disabled via .preset-only-mode.
-             Tenants paste their access key into the unlock input; the JS
-             re-validates against /server-caps and removes the body class. -->
+        <!-- Public-tier informational banner (Phase 11 follow-up).
+             Shown whenever /server-caps reports preset_enabled=true —
+             the public-tier marker. Tenants who want custom rendering
+             run a private instance (separate URL); they never need to
+             "unlock" the public configurator with a key, so there's no
+             input here. Two CTAs explain how to get one. -->
         <div class="lock-banner" id="lock-banner">
           <div class="lock-banner-title">Public access — preset selection only</div>
           <div class="lock-banner-body">
-            Pick a preset below to generate a shareable poster URL. Custom
-            rendering (sliders, weights, sash priority) is reserved for
-            tenants. Paste your access key to unlock.
+            To keep the public instance scalable, customization is limited
+            to the presets below. For full per-poster control (sliders,
+            weights, sash priority), run your own instance:
           </div>
-          <div class="lock-banner-row">
-            <input type="text" id="cfg-access-key-input"
-                   placeholder="access key"
-                   autocomplete="off" spellcheck="false"
-                   oninput="onAccessKeyInput()">
-            <span class="lock-banner-status" id="lock-banner-status"></span>
+          <div class="lock-banner-cta-row">
+            <a class="lock-banner-cta primary"
+               href="https://store.elfhosted.com"
+               target="_blank" rel="noopener noreferrer">
+              <span class="lock-banner-cta-label">Get a private instance</span>
+              <span class="lock-banner-cta-sub">elfhosted.com — managed</span>
+            </a>
+            <a class="lock-banner-cta"
+               href="https://github.com/UmbraProjects/PostersPlus"
+               target="_blank" rel="noopener noreferrer">
+              <span class="lock-banner-cta-label">Self-host</span>
+              <span class="lock-banner-cta-sub">github.com — upstream source</span>
+            </a>
           </div>
         </div>
 
@@ -1773,13 +1794,13 @@ const qs = new URLSearchParams(window.location.search);
 (function deriveAuthFromUrl() {
   const domain = window.location.origin;
   document.getElementById('cfg-domain').value = domain;
+  // cfg-access-key is still populated from URL/localStorage for legacy
+  // tenant tooling that points at a private instance with ?access_key=…
+  // in the URL. On a public-tier deployment the field stays empty and
+  // the preset-only lock banner handles the UX.
   const ak = qs.get('access_key') || localStorage.getItem('postersplus_access_key') || '';
   document.getElementById('cfg-access-key').value = ak;
   if (ak) localStorage.setItem('postersplus_access_key', ak);
-  // Mirror into the lock-banner visible input so tenants returning from
-  // a previous session see their key already populated.
-  const visible = document.getElementById('cfg-access-key-input');
-  if (visible && ak) visible.value = ak;
 })();
 
 const MOVIE_SOURCES = ['letterboxd','trakt','tomatoes','popcorn','imdb','metacritic','metacriticuser','tmdb','rogerebert','myanimelist'];
@@ -1815,7 +1836,7 @@ const SASH_SLOTS = [
 let sashOrder    = SASH_SLOTS.map(s => s.id);
 let sashDisabled = new Set();   // IDs explicitly disabled via ✕ button
 let mediaType = 'movie', resolvedImdbId = '', resolvedTmdbId = '';
-let serverCaps = { tmdb_key_set: false, mdblist_key_set: false, aiostreams_configured: false, preset_enabled: false, presets: [], access_key_required: false, access_key_valid: true };
+let serverCaps = { tmdb_key_set: false, mdblist_key_set: false, aiostreams_configured: false, preset_enabled: false, presets: [], access_key_valid: true };
 let searchDebounce = null, previewDebounce = null, previewLoading = false, imdbResolvePending = false;
 
 const previewPanel = document.querySelector('.preview-panel');
@@ -1892,6 +1913,9 @@ function updateWeightRange(el, outId) {
 
 async function fetchServerCaps() {
   try {
+    // Pass cfg-access-key (populated from URL/localStorage at boot) so
+    // the legacy ?access_key=… escape hatch can unlock the configurator
+    // on a public-tier instance for someone routing a tenant client at it.
     const ak = vEl('cfg-access-key');
     const url = ak ? `/server-caps?access_key=${encodeURIComponent(ak)}` : '/server-caps';
     const resp = await fetch(url);
@@ -1970,17 +1994,24 @@ function updateKeyBadges() {
 }
 
 function applyLockMode() {
-  const lock = serverCaps.access_key_required && !serverCaps.access_key_valid;
+  // The lock is the public-tier marker: on a deployment with
+  // preset_enabled=true the configurator drops into preset-only mode.
+  // Tenants who want custom rendering run a private instance, so the
+  // banner shows CTAs (store + self-host) instead of an unlock input.
+  //
+  // Legacy escape hatch: a URL like ?access_key=<valid-key> still
+  // unlocks the UI on a preset-enabled instance — the access_key flows
+  // through cfg-access-key into the /server-caps validation and
+  // access_key_valid clears the lock. Useful if someone deliberately
+  // routes a tenant client at the public host; not surfaced in the UI.
+  const lock = !!serverCaps.preset_enabled && !serverCaps.access_key_valid;
   document.body.classList.toggle('preset-only-mode', lock);
 
-  // The "Custom" option in the preset dropdown is option index 0
-  // (value=""). When locked AND presets are enabled, hide it so users
-  // can't pick a setting that would emit a /poster URL with
-  // default-but-invisible params. When presets are NOT enabled, leave
-  // it alone — forcing "default" while the backend serves 404 on /p
-  // routes is worse UX than the visible lock banner alone.
+  // Hide the "Custom" option in the preset dropdown so the locked UI
+  // can only emit /p/... URLs; force "default" as the active preset
+  // if nothing else is selected yet.
   const presetField = document.getElementById('cfg-preset');
-  if (presetField && serverCaps.preset_enabled) {
+  if (presetField) {
     const customOpt = presetField.querySelector('option[value=""]');
     if (customOpt) customOpt.hidden = lock;
     if (lock && (!presetField.value || presetField.value === '')) {
@@ -1989,41 +2020,6 @@ function applyLockMode() {
       build();
     }
   }
-
-  // Lock-banner status indicator.
-  const statusEl = document.getElementById('lock-banner-status');
-  if (statusEl) {
-    if (!serverCaps.access_key_required) {
-      statusEl.textContent = '';
-      statusEl.className = 'lock-banner-status';
-    } else if (serverCaps.access_key_valid) {
-      statusEl.textContent = 'UNLOCKED';
-      statusEl.className = 'lock-banner-status ok';
-    } else if (vEl('cfg-access-key')) {
-      statusEl.textContent = 'INVALID';
-      statusEl.className = 'lock-banner-status err';
-    } else {
-      statusEl.textContent = 'LOCKED';
-      statusEl.className = 'lock-banner-status info';
-    }
-  }
-}
-
-// Debounced re-validation when the user types into the lock-banner input.
-let _accessKeyDebounce = null;
-function onAccessKeyInput() {
-  const visible = document.getElementById('cfg-access-key-input');
-  const hidden  = document.getElementById('cfg-access-key');
-  if (!visible || !hidden) return;
-  const value = visible.value.trim();
-  hidden.value = value;
-  // Persist so a page reload doesn't re-lock a tenant who's already
-  // entered their key. localStorage was already the canonical storage
-  // for cfg-access-key in the upstream flow.
-  if (value) localStorage.setItem('postersplus_access_key', value);
-  else       localStorage.removeItem('postersplus_access_key');
-  clearTimeout(_accessKeyDebounce);
-  _accessKeyDebounce = setTimeout(() => { fetchServerCaps(); }, 250);
 }
 
 function updateBadgeModeHint() {

--- a/configurator.html
+++ b/configurator.html
@@ -3,7 +3,84 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Posters+ // Web</title>
+
+<!-- SEO + LLM discovery (Phase 11 follow-up). Keywords are chosen to
+     match what users actually type when they're looking for a Stremio
+     poster overlay — "stremio poster addon", "stremio ratings",
+     "cinemeta replacement" — plus competitor-adjacent brand mentions
+     (BetterPosters, RPDB, AIOratings) in the JSON-LD so LLM scrapers
+     surface Posters+ alongside them. The /static/llms.txt at the root
+     follows the emerging llmstxt.org convention for site summaries. -->
+<title>Posters+ — Stremio Poster Addon · Ratings, Awards, Badges</title>
+<meta name="description" content="Enrich Stremio posters with weighted IMDB · Rotten Tomatoes · Letterboxd ratings, award sashes (Oscar, Emmy, Cannes) &amp; quality badges. Free hosted by ElfHosted.">
+<meta name="keywords" content="stremio poster addon, stremio ratings, stremio posters, cinemeta replacement, IMDB Rotten Tomatoes ratings stremio, betterposters alternative, rpdb alternative, stremio award badges, stremio quality badges">
+<meta name="robots" content="index, follow">
+<meta name="theme-color" content="#0a0a0b">
+
+<!-- Open Graph / Twitter Card. og:image references the canonical
+     ElfHosted logo SVG — sufficient as a brand thumbnail until a
+     proper "before / after" poster screenshot is captured. -->
+<meta property="og:type" content="website">
+<meta property="og:title" content="Posters+ — Stremio Poster Addon · Ratings, Awards, Badges">
+<meta property="og:description" content="Enrich Stremio posters with weighted IMDB · Rotten Tomatoes · Letterboxd ratings, award sashes (Oscar, Emmy, Cannes) &amp; quality badges. Free hosted by ElfHosted.">
+<meta property="og:image" content="https://docs.elfhosted.com/images/logo.svg">
+<meta property="og:site_name" content="ElfHosted">
+<meta name="twitter:card" content="summary">
+<meta name="twitter:title" content="Posters+ — Stremio Poster Addon · Ratings, Awards, Badges">
+<meta name="twitter:description" content="Enrich Stremio posters with weighted IMDB, Rotten Tomatoes &amp; Letterboxd ratings, award sashes and quality badges. Free hosted by ElfHosted.">
+<meta name="twitter:image" content="https://docs.elfhosted.com/images/logo.svg">
+
+<!-- Schema.org structured data. Anchors Posters+ in the
+     SoftwareApplication category, names the closest competitors via
+     isSimilarTo, and exposes the public/private offer split so search
+     engines (and LLMs that read JSON-LD) can summarise the product
+     without scraping the JS-rendered UI. -->
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  "name": "Posters+",
+  "alternateName": ["PostersPlus", "Posters Plus"],
+  "applicationCategory": "MultimediaApplication",
+  "applicationSubCategory": "Stremio Addon",
+  "operatingSystem": "Web",
+  "description": "Stremio poster addon that overlays weighted ratings (IMDB, Rotten Tomatoes, Letterboxd, Trakt, MyAnimeList), award sashes (Oscar, Emmy, Golden Globe, Cannes, festival winners) and quality badges (4K, HDR, Dolby Vision) on Stremio posters. A free public preset-only tier is hosted by ElfHosted; private managed instances and self-hosting offer full per-poster customisation.",
+  "url": "https://posters.elfhosted.com",
+  "image": "https://docs.elfhosted.com/images/logo.svg",
+  "offers": [
+    {
+      "@type": "Offer",
+      "name": "Public — preset selection",
+      "price": "0",
+      "priceCurrency": "USD",
+      "description": "Anonymous access to six visual presets via /p/{preset}/{type}/{imdb_id}.jpg URLs."
+    },
+    {
+      "@type": "Offer",
+      "name": "Private managed instance",
+      "url": "https://store.elfhosted.com?utm_source=postersplus&utm_medium=jsonld&utm_campaign=offer_private",
+      "description": "Managed private deployment with full per-poster customisation (sliders, weights, sash priority)."
+    }
+  ],
+  "publisher": {
+    "@type": "Organization",
+    "name": "ElfHosted",
+    "url": "https://elfhosted.com",
+    "logo": "https://docs.elfhosted.com/images/logo.svg"
+  },
+  "isBasedOn": {
+    "@type": "SoftwareApplication",
+    "name": "PostersPlus",
+    "url": "https://github.com/UmbraProjects/PostersPlus"
+  },
+  "isSimilarTo": [
+    {"@type": "SoftwareApplication", "name": "BetterPosters", "url": "https://btttr.cc/"},
+    {"@type": "SoftwareApplication", "name": "Rating Poster Database (RPDB)", "url": "https://ratingposterdb.com/"},
+    {"@type": "SoftwareApplication", "name": "AIOratings", "url": "https://aioratings.com/"}
+  ]
+}
+</script>
+
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="icon" type="image/png" href="/static/favicon.png">
 <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;500;600&family=DM+Mono:wght@300;400;500&display=swap" rel="stylesheet">
@@ -91,7 +168,28 @@
     letter-spacing: 0.25em;
     color: var(--gold);
     text-transform: uppercase;
+    /* h1 default browser styles reset (we promoted span→h1 for SEO
+       semantics; the visual rendering is unchanged). */
+    margin: 0;
+    line-height: 1;
+    display: inline-block;
   }
+  /* Make the no-JS summary look like a real page, not raw browser
+     defaults, when JavaScript is disabled. Browsers with JS enabled
+     don't render <noscript> contents at all so these rules are
+     effectively only consulted by the no-JS fallback path. */
+  .noscript-summary {
+    max-width: 760px;
+    margin: 40px auto;
+    padding: 0 24px;
+    font-family: var(--mono);
+    color: var(--silver);
+    line-height: 1.6;
+  }
+  .noscript-summary h1 { color: var(--gold); font-family: var(--serif); font-weight: 400; letter-spacing: 0.1em; }
+  .noscript-summary h2 { color: var(--gold-dim); font-family: var(--mono); font-size: 12px; letter-spacing: 0.2em; text-transform: uppercase; margin-top: 28px; }
+  .noscript-summary a { color: var(--gold); }
+  .noscript-summary strong { color: var(--gold); font-weight: 500; }
 
   .logo em {
     font-style: normal;
@@ -1311,12 +1409,69 @@
 </head>
 <body>
 
+<!-- LLM-readable summary. Crawlers and scrapers that don't execute the
+     configurator JS see only the <head>; this block gives them a
+     substantive, keyword-dense description of what Posters+ is, what it
+     does, and where the public/private/self-host paths live. Hidden via
+     CSS for regular visitors who get the rich JS UI below; .noscript-
+     summary[hidden] is honoured by browsers automatically when JS runs
+     so we don't actually need a manual hide, but we mark it inside a
+     <noscript> wrapper anyway for the cleanest semantic. -->
+<noscript>
+<main class="noscript-summary">
+  <h1>Posters+ — Stremio Poster Addon</h1>
+  <p>
+    <strong>Posters+</strong> is a Stremio poster addon that enriches
+    your Stremio catalogue with overlaid information: weighted ratings
+    from IMDB, Rotten Tomatoes, Letterboxd, Metacritic, Trakt and
+    MyAnimeList; award sashes for Oscar, Emmy, Golden Globe, Cannes
+    and other festival winners; and quality badges (4K, 1080p, HDR,
+    Dolby Vision, Remux) on Stremio movie and TV posters. It's an
+    alternative to <a href="https://btttr.cc/">BetterPosters</a>,
+    <a href="https://ratingposterdb.com/">RPDB</a> and
+    <a href="https://aioratings.com/">AIOratings</a>, designed as a
+    Cinemeta-replacement poster source for Stremio addons that consume
+    poster URLs (notably AIOMetadata).
+  </p>
+  <h2>How to use Posters+</h2>
+  <p>
+    The public hosted instance offers six fixed visual presets — pick
+    one and embed the resulting <code>/p/&lt;preset&gt;/&lt;type&gt;/&lt;imdb_id&gt;.jpg</code>
+    URL in any Stremio addon that takes a custom poster URL pattern.
+    Available presets: default, awards (sash-forward), minimalist,
+    letterboxd (Letterboxd-weighted), cinephile (prestige sash
+    priority), and quality (cached badges visible).
+  </p>
+  <h2>More options</h2>
+  <ul>
+    <li>
+      <strong><a href="https://store.elfhosted.com?utm_source=postersplus&amp;utm_medium=noscript&amp;utm_campaign=noscript_store">Get a private instance</a></strong>
+      — managed by ElfHosted, full per-poster customisation (sliders,
+      weights, sash priority).
+    </li>
+    <li>
+      <strong><a href="https://github.com/UmbraProjects/PostersPlus">Self-host</a></strong>
+      — upstream open-source project on GitHub.
+    </li>
+    <li>
+      Explore more
+      <strong><a href="https://stremio-addons-guide.elfhosted.com/?utm_source=postersplus&amp;utm_medium=noscript&amp;utm_campaign=noscript_addons_guide">best Stremio addons</a></strong>
+      hosted and reviewed by ElfHosted.
+    </li>
+  </ul>
+  <p>
+    Hosted by <a href="https://elfhosted.com?utm_source=postersplus&amp;utm_medium=noscript&amp;utm_campaign=noscript_brand">ElfHosted</a>
+    — [s]elf hosting without [s]uffering.
+  </p>
+</main>
+</noscript>
+
 <div class="shell">
 
   <header class="header">
     <div class="header-left">
       <div>
-        <span class="logo"><em>Posters</em>+</span>
+        <h1 class="logo"><em>Posters</em>+</h1>
         <span class="logo-sep">//</span>
         <span class="logo-sub">Web Configurator</span>
       </div>

--- a/configurator.html
+++ b/configurator.html
@@ -1013,6 +1013,26 @@
     text-transform: uppercase;
     color: var(--silver-dim);
   }
+  .lock-banner-explore {
+    margin-top: 14px;
+    padding-top: 12px;
+    border-top: 1px dashed var(--border);
+    text-align: center;
+  }
+  .lock-banner-explore-link {
+    font-family: var(--mono);
+    font-size: 10px;
+    letter-spacing: 0.1em;
+    color: var(--silver-dim);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .lock-banner-explore-link strong {
+    color: var(--gold);
+    font-weight: 500;
+  }
+  .lock-banner-explore-link:hover { color: var(--silver); }
+  .lock-banner-explore-link:hover strong { color: var(--gold-bright); }
 
   /* Anything below Core Config (i.e. the visual configuration sections)
      is locked out when preset-only-mode is active. The user can still
@@ -1327,7 +1347,9 @@
          metadata. Loading it from docs.elfhosted.com keeps the
          configurator HTML small and lets the asset evolve without a
          redeploy here. -->
-    <a class="header-right" href="https://elfhosted.com" target="_blank" rel="noopener noreferrer">
+    <a class="header-right"
+       href="https://elfhosted.com?utm_source=postersplus&utm_medium=configurator&utm_campaign=header_brand"
+       target="_blank" rel="noopener noreferrer">
       <img class="hosted-by-logo"
            src="https://docs.elfhosted.com/images/logo.svg"
            alt="ElfHosted"
@@ -1335,7 +1357,7 @@
       <div>
         <div class="hosted-by-label">Hosted by</div>
         <div class="hosted-by-brand">ElfHosted</div>
-        <div class="hosted-by-tagline">Open-source apps · Managed</div>
+        <div class="hosted-by-tagline">[s]elf hosting without [s]uffering</div>
       </div>
     </a>
   </header>
@@ -1369,7 +1391,7 @@
           </div>
           <div class="lock-banner-cta-row">
             <a class="lock-banner-cta primary"
-               href="https://store.elfhosted.com"
+               href="https://store.elfhosted.com?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_store"
                target="_blank" rel="noopener noreferrer">
               <span class="lock-banner-cta-label">Get a private instance</span>
               <span class="lock-banner-cta-sub">elfhosted.com — managed</span>
@@ -1379,6 +1401,18 @@
                target="_blank" rel="noopener noreferrer">
               <span class="lock-banner-cta-label">Self-host</span>
               <span class="lock-banner-cta-sub">github.com — upstream source</span>
+            </a>
+          </div>
+          <!-- Stremio addons guide CTA. Anchor text deliberately uses the
+               exact "best Stremio addons" phrase for SEO weight on the
+               target page (it's the canonical landing page for that
+               keyword). UTM-tagged so the guide can attribute referrals
+               back to which PostersPlus surface drove the click. -->
+          <div class="lock-banner-explore">
+            <a class="lock-banner-explore-link"
+               href="https://stremio-addons-guide.elfhosted.com/?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_addons_guide"
+               target="_blank" rel="noopener noreferrer">
+              Explore more — the <strong>best Stremio addons</strong>, hosted &amp; reviewed &rarr;
             </a>
           </div>
         </div>

--- a/configurator.html
+++ b/configurator.html
@@ -116,6 +116,46 @@
     text-transform: uppercase;
   }
 
+  /* ElfHosted brand block — right-aligned in the header beside the
+     POSTERS+ logo. Matches the existing mono + caps + gold/silver-dim
+     aesthetic; SVG icon scales with the surrounding text. */
+  .header-right {
+    display: flex;
+    align-items: center;
+    gap: 14px;
+    text-decoration: none;
+    color: inherit;
+  }
+  .header-right:hover .hosted-by-brand { color: var(--gold-bright); }
+  .header-right svg { display: block; }
+  .hosted-by-label {
+    font-family: var(--mono);
+    font-size: 9px;
+    font-weight: 300;
+    color: var(--silver-dim);
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    line-height: 1.5;
+  }
+  .hosted-by-brand {
+    font-family: var(--serif);
+    font-size: 16px;
+    font-weight: 400;
+    color: var(--gold);
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    transition: color 0.15s ease;
+  }
+  .hosted-by-tagline {
+    font-family: var(--mono);
+    font-size: 9px;
+    font-weight: 300;
+    color: var(--silver-dim);
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    margin-top: 2px;
+  }
+
   .status-bar {
     display: flex;
     align-items: center;
@@ -1177,6 +1217,25 @@
         <span class="logo-sub">Web Configurator</span>
       </div>
     </div>
+
+    <!-- ElfHosted brand block — replace the inline <svg> below with the
+         real ElfHosted logo when you have it. Keeping it inline (rather
+         than referencing /static/) so the configurator stays a single
+         self-contained file. -->
+    <a class="header-right" href="https://elfhosted.com" target="_blank" rel="noopener noreferrer">
+      <svg width="36" height="36" viewBox="0 0 36 36" fill="none" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <!-- placeholder mark: stylised "elf hat" silhouette. Swap for the
+             real logo SVG when ready. -->
+        <path d="M18 4 L8 26 L28 26 Z" stroke="#c9a14a" stroke-width="1.4" fill="none"/>
+        <circle cx="18" cy="30" r="2" fill="#e6c068"/>
+        <path d="M14 26 H22" stroke="#c9a14a" stroke-width="1.4" stroke-linecap="round"/>
+      </svg>
+      <div>
+        <div class="hosted-by-label">Hosted by</div>
+        <div class="hosted-by-brand">ElfHosted</div>
+        <div class="hosted-by-tagline">Open-source apps · Managed</div>
+      </div>
+    </a>
   </header>
 
   <div class="main-layout">
@@ -1201,6 +1260,27 @@
             <span class="section-chevron">▼</span>
           </div>
           <div class="section-body">
+
+            <!-- Preset mode (Phase 11). When a preset is selected the
+                 emitted URL switches to /p/{preset}/{type}/{imdb_id}.jpg —
+                 anonymous, CDN-cacheable, server-side keys only. Custom
+                 (the default) uses the full /poster URL with every field
+                 below as a query param. -->
+            <div class="field">
+              <label class="field-label">Preset Mode</label>
+              <select id="cfg-preset" oninput="onPresetChange()">
+                <option value="" selected>Custom (use settings below)</option>
+                <option value="default">default — standard look</option>
+                <option value="awards">awards — sash-forward, no score</option>
+                <option value="minimalist">minimalist — small genre, no bar</option>
+                <option value="letterboxd">letterboxd — numeric score, no sash</option>
+                <option value="cinephile">cinephile — prestige sash priority</option>
+                <option value="quality">quality — score + cached badges</option>
+              </select>
+              <div class="field-hint" id="preset-hint" style="display:none;color:var(--gold-dim);font-size:9px;margin-top:6px;line-height:1.4;">
+                Preset mode emits the short <code>/p/&hellip;</code> URL. Server-side TMDB key is required; the configuration sections below are bypassed.
+              </div>
+            </div>
 
             <div class="field">
               <label class="field-label">Content Search</label>
@@ -1624,7 +1704,7 @@ const SASH_SLOTS = [
 let sashOrder    = SASH_SLOTS.map(s => s.id);
 let sashDisabled = new Set();   // IDs explicitly disabled via ✕ button
 let mediaType = 'movie', resolvedImdbId = '', resolvedTmdbId = '';
-let serverCaps = { tmdb_key_set: false, mdblist_key_set: false, aiostreams_configured: false };
+let serverCaps = { tmdb_key_set: false, mdblist_key_set: false, aiostreams_configured: false, preset_enabled: false, presets: [] };
 let searchDebounce = null, previewDebounce = null, previewLoading = false, imdbResolvePending = false;
 
 const previewPanel = document.querySelector('.preview-panel');
@@ -1739,6 +1819,27 @@ function updateKeyBadges() {
   const aiosHint = document.getElementById('aiostreams-hint');
   if (aiosHint) {
     aiosHint.style.display = serverCaps.aiostreams_configured ? 'none' : '';
+  }
+
+  // Phase 11: hide the preset selector entirely on instances that haven't
+  // opted into the public preset endpoint (PRESET_ENABLED unset/false).
+  // The dropdown's options would emit /p/... URLs that 404 against this
+  // backend, so it's better to remove the temptation than to render dead
+  // links. If a preset is already selected (e.g. via URL import) clear it
+  // so the URL output reverts to /poster form.
+  const presetField = document.getElementById('cfg-preset');
+  if (presetField) {
+    const fieldWrap = presetField.closest('.field');
+    if (serverCaps.preset_enabled) {
+      if (fieldWrap) fieldWrap.style.display = '';
+    } else {
+      if (fieldWrap) fieldWrap.style.display = 'none';
+      if (presetField.value) {
+        presetField.value = '';
+        refreshPresetUiState();
+        build();
+      }
+    }
   }
 }
 
@@ -2262,6 +2363,18 @@ function decodePlaceholders(url) {
   return url.replace(/%7B/g, '{').replace(/%7D/g, '}');
 }
 
+function refreshPresetUiState() {
+  const preset = vEl('cfg-preset');
+  const hint = document.getElementById('preset-hint');
+  if (hint) hint.style.display = preset ? 'block' : 'none';
+  document.body.classList.toggle('preset-active', !!preset);
+}
+
+function onPresetChange() {
+  refreshPresetUiState();
+  build();
+}
+
 function buildBaseParams({ usePlaceholders = false } = {}) {
   const domain   = vEl('cfg-domain').replace(/\/$/, '') || 'https://your-instance.com';
   const logoLanguage = vEl('cfg-language') || 'en';
@@ -2269,6 +2382,19 @@ function buildBaseParams({ usePlaceholders = false } = {}) {
   const tmdbId   = usePlaceholders ? '{tmdb_id}'  : (resolvedTmdbId  || '{tmdb_id}');
   const accKey   = vEl('cfg-access-key');
   const type     = usePlaceholders ? '{type}'     : mediaType;
+
+  // Phase 11: preset mode short-circuits the full param URL. The /p
+  // endpoint takes only (preset, type, imdb_id) and pulls visual params
+  // server-side from presets.py, so the configurator's other fields are
+  // intentionally not included in the URL when a preset is selected.
+  const preset = vEl('cfg-preset');
+  if (preset) {
+    // Type in the path is movie|tv (no "series" variant on the preset
+    // endpoint); fold series→tv to match the route's validator.
+    const presetType = (type === 'series') ? 'tv' : type;
+    const presetUrl = `${domain}/p/${preset}/${presetType}/${imdbId}.jpg`;
+    return usePlaceholders ? decodePlaceholders(presetUrl) : presetUrl;
+  }
   const userTmdbKey    = vEl('cfg-tmdb-key');
   const userMdblistKey = vEl('cfg-mdblist-key');
   const params = new URLSearchParams();
@@ -2340,6 +2466,7 @@ function resetDefaults() {
   sashDisabled = new Set();
   localStorage.removeItem('postersplus_sash_order');
   buildSashList();
+  refreshPresetUiState();
   build();
   collapsePreview();
   setLog('preview-log', 'Reset to defaults. API keys preserved.', 'info');
@@ -2348,7 +2475,9 @@ function resetDefaults() {
 function queuePreviewReload() {
   clearTimeout(previewDebounce);
   previewDebounce = setTimeout(() => {
-    if (resolvedImdbId && resolvedTmdbId) loadPreview();
+    // Preset mode needs only imdb_id; custom mode still needs both.
+    const presetMode = !!vEl('cfg-preset');
+    if (presetMode ? resolvedImdbId : (resolvedImdbId && resolvedTmdbId)) loadPreview();
   }, 350);
 }
 
@@ -2361,8 +2490,17 @@ function setLog(id, msg, cls='') {
 async function loadPreview() {
   if (previewLoading) { clearTimeout(previewDebounce); return; }
   if (imdbResolvePending) return;
-  if (!resolvedImdbId || !resolvedTmdbId) { setLog('preview-log', 'Search and select a title first', 'err'); return; }
-  if (!vEl('cfg-tmdb-key') && !serverCaps.tmdb_key_set) { setLog('preview-log', 'This instance has no server side TMDB key. You must provide your own or ask the operator to add one.', 'err'); return; }
+  // Phase 11: preset mode only needs an IMDb id (the server resolves to
+  // TMDB id from there); custom mode still requires both. Likewise the
+  // user-side TMDB key requirement is for /poster — /p uses the operator's
+  // server key exclusively.
+  const presetMode = !!vEl('cfg-preset');
+  if (presetMode) {
+    if (!resolvedImdbId) { setLog('preview-log', 'Search and select a title first', 'err'); return; }
+  } else {
+    if (!resolvedImdbId || !resolvedTmdbId) { setLog('preview-log', 'Search and select a title first', 'err'); return; }
+    if (!vEl('cfg-tmdb-key') && !serverCaps.tmdb_key_set) { setLog('preview-log', 'This instance has no server side TMDB key. You must provide your own or ask the operator to add one.', 'err'); return; }
+  }
   previewLoading = true;
   document.getElementById('preview-status').textContent = 'LOADING';
   const frame = document.getElementById('preview-frame');
@@ -2371,7 +2509,9 @@ async function loadPreview() {
     frame.innerHTML = `<div class="preview-empty"><div class="preview-spinner"></div>Fetching poster…</div>`;
   }
   setLog('preview-log', 'fetching poster…', 'info');
-  const previewUrl = buildPreviewUrl() + '&_ts=' + Date.now();
+  // Cache-bust without breaking path-only preset URLs (no existing `?`).
+  const baseUrl = buildPreviewUrl();
+  const previewUrl = baseUrl + (baseUrl.includes('?') ? '&' : '?') + '_ts=' + Date.now();
   const existingImg = frame.querySelector('.preview-poster');
   if (existingImg) {
     existingImg.style.opacity = '0.3';
@@ -2462,13 +2602,35 @@ function importUrl(urlStr) {
     return false;
   }
 
+  // Phase 11: also accept /p/{preset}/{type}/{imdb_id}.jpg preset URLs.
+  // Path components are positional, no query params expected.
+  const presetMatch = parsed.pathname.match(/^\/p\/([^\/]+)\/(movie|tv)\/(tt\d+)\.jpg\/?$/);
+  if (presetMatch) {
+    const [, preset, presetType, imdbId] = presetMatch;
+    document.getElementById('cfg-domain').value = parsed.origin;
+    resolvedImdbId = imdbId;
+    mediaType      = presetType;
+    _setEl('cfg-preset', preset);
+    refreshPresetUiState();
+    build();
+    setLog('preview-log', `Imported preset URL: ${preset} / ${presetType} / ${imdbId}.`, 'ok');
+    return true;
+  }
+
   // Only accept /poster paths
   if (!parsed.pathname.endsWith('/poster') && !parsed.pathname.endsWith('/poster/')) {
-    setLog('preview-log', 'Import failed — URL does not look like a poster endpoint (/poster).', 'err');
+    setLog('preview-log', 'Import failed — URL does not look like a poster endpoint (/poster or /p/…).', 'err');
     return false;
   }
 
   const p = parsed.searchParams;
+
+  // Phase 11: a /poster URL is by definition custom mode. Clear any
+  // previously-selected preset so the rebuilt output URL stays in /poster
+  // form instead of re-emitting /p/{preset}/... with the imported values
+  // silently dropped.
+  _setEl('cfg-preset', '');
+  refreshPresetUiState();
 
   // ── Domain & auth ──────────────────────────────────────────────────────
   document.getElementById('cfg-domain').value = parsed.origin;

--- a/main.py
+++ b/main.py
@@ -936,6 +936,20 @@ async def readiness_probe():
     return {"status": "ok", **body}
 
 
+@app.api_route("/llms.txt", methods=["GET", "HEAD"], response_class=Response)
+async def get_llms_txt():
+    """llmstxt.org convention — serve the LLM-readable site summary at
+    the root path. The file lives under static/ for editability but
+    must be reachable at /llms.txt per the spec. HEAD is supported so
+    crawlers that probe before fetching don't see a 405."""
+    path = os.path.join(BASE_DIR, "static", "llms.txt")
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return Response(content=f.read(), media_type="text/markdown")
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail="llms.txt not found")
+
+
 @app.get("/", response_class=HTMLResponse)
 async def get_configurator(access_key: str = ""):
     # Conditionally anonymous (Phase 11 follow-up):

--- a/main.py
+++ b/main.py
@@ -803,28 +803,35 @@ async def remove_server_header(request: Request, call_next):
 
 @app.get("/server-caps")
 async def server_caps(access_key: str = ""):
-    # Phase 11 follow-up: /server-caps is anonymous so the configurator
-    # can boot without an access_key and present preset-only mode to public
-    # visitors. `access_key_required` tells the UI whether the operator
-    # has a key configured (i.e. should lock the advanced controls), and
-    # `access_key_valid` reports whether the supplied key matches — so
-    # tenants can paste their key and watch the UI unlock without the
-    # backend having to leak the secret. The real security boundary is
-    # /poster, which still rejects a missing or wrong access_key.
-    access_key_required = bool(_cfg.ACCESS_KEY)
-    if access_key_required:
-        access_key_valid = bool(
-            access_key and hmac.compare_digest(access_key, _cfg.ACCESS_KEY)
-        )
-    else:
-        access_key_valid = True   # no lock configured → everything open
+    # Anonymous (Phase 11 follow-up). Reports what this instance can do
+    # so the configurator can adapt: on a public-tier deployment
+    # (preset_enabled=true) the UI drops into preset-only mode with an
+    # informational banner; on a private/self-hosted instance
+    # (preset_enabled=false) the full configurator is available.
+    #
+    # access_key_valid is reported as a legacy escape hatch — there's no
+    # UI input for it on the configurator (tenants run their own
+    # instance), but a URL like ?access_key=… still works if someone
+    # routes a tenant client at the public host. The real security
+    # boundary is /poster, which gates server-side independently.
+    # `access_key_valid` here is the escape-hatch signal for the
+    # configurator lock — only true when there's a configured server key
+    # AND the supplied key matches. When ACCESS_KEY is unset, there's no
+    # escape hatch on offer (and on a preset-enabled instance that means
+    # the lock stays on, which is what we want — the public-tier UX
+    # shouldn't accidentally unlock just because the operator left the
+    # server key blank).
+    access_key_valid = bool(
+        _cfg.ACCESS_KEY
+        and access_key
+        and hmac.compare_digest(access_key, _cfg.ACCESS_KEY)
+    )
     return {
         "tmdb_key_set":          bool(_cfg.SERVER_TMDB_KEY),
         "mdblist_key_set":       bool(_cfg.SERVER_MDBLIST_KEY),
         "aiostreams_configured": bool(_cfg.AIOSTREAMS_URL and _cfg.AIOSTREAMS_AUTH),
         "preset_enabled":        _cfg.PRESET_ENABLED,
         "presets":               preset_names() if _cfg.PRESET_ENABLED else [],
-        "access_key_required":   access_key_required,
         "access_key_valid":      access_key_valid,
     }
 
@@ -930,13 +937,23 @@ async def readiness_probe():
 
 
 @app.get("/", response_class=HTMLResponse)
-async def get_configurator():
-    # Anonymous (Phase 11 follow-up). The configurator page itself is
-    # safe to serve to anyone: the JS detects whether the server requires
-    # an access_key and, when it does, locks every control that drives
-    # /poster output until the user enters a valid key. /poster keeps its
-    # access_key gate server-side, so this is purely a UX surface — the
-    # security boundary doesn't move.
+async def get_configurator(access_key: str = ""):
+    # Conditionally anonymous (Phase 11 follow-up):
+    #
+    # * Public-tier (PRESET_ENABLED=true) — anonymous. The JS shows a
+    #   preset-only banner with CTAs to a private instance / self-host;
+    #   /poster keeps its server-side ACCESS_KEY gate so the lock can't
+    #   be bypassed.
+    # * Private-tier (PRESET_ENABLED=false) — the original behaviour
+    #   stands: a configured ACCESS_KEY still gates the configurator
+    #   itself, since there's no visible unlock UI for tenants to enter
+    #   it through. Tenants reach the page via ?access_key=… as before.
+    if (
+        _cfg.ACCESS_KEY
+        and not _cfg.PRESET_ENABLED
+        and not hmac.compare_digest(access_key, _cfg.ACCESS_KEY)
+    ):
+        raise HTTPException(status_code=403, detail="Unauthorized. Provide ?access_key=<key>")
     return HTMLResponse(content=_configurator_html or _load_configurator_html())
 
 
@@ -1116,8 +1133,24 @@ async def get_poster(
     logo_language: str | None = None,
     sash_priority: str | None = None,
 ):
-    if _cfg.ACCESS_KEY and not hmac.compare_digest(access_key, _cfg.ACCESS_KEY):
-        raise HTTPException(status_code=403, detail="Unauthorized, your access key is not valid for this instance.")
+    # Auth gate matches the configurator's preset-only model. When
+    # PRESET_ENABLED=true this is a public-tier deployment and /poster
+    # is restricted to authenticated tenants — anonymous custom
+    # rendering is reserved for /p/{preset}/... so the UI lock can't
+    # be bypassed by hand-rolled URLs. When ACCESS_KEY is unset on a
+    # preset-enabled instance there's no key to validate against and
+    # /poster is effectively disabled (only /p works) — fail loud
+    # rather than silently allowing anonymous custom renders.
+    if _cfg.PRESET_ENABLED or _cfg.ACCESS_KEY:
+        if not (
+            _cfg.ACCESS_KEY
+            and access_key
+            and hmac.compare_digest(access_key, _cfg.ACCESS_KEY)
+        ):
+            raise HTTPException(
+                status_code=403,
+                detail="Unauthorized, your access key is not valid for this instance.",
+            )
 
     _check_tmdb_id(tmdb_id)
     _check_imdb_id(imdb_id)

--- a/main.py
+++ b/main.py
@@ -803,14 +803,29 @@ async def remove_server_header(request: Request, call_next):
 
 @app.get("/server-caps")
 async def server_caps(access_key: str = ""):
-    if _cfg.ACCESS_KEY and not hmac.compare_digest(access_key, _cfg.ACCESS_KEY):
-        raise HTTPException(status_code=403, detail="Unauthorized")
+    # Phase 11 follow-up: /server-caps is anonymous so the configurator
+    # can boot without an access_key and present preset-only mode to public
+    # visitors. `access_key_required` tells the UI whether the operator
+    # has a key configured (i.e. should lock the advanced controls), and
+    # `access_key_valid` reports whether the supplied key matches — so
+    # tenants can paste their key and watch the UI unlock without the
+    # backend having to leak the secret. The real security boundary is
+    # /poster, which still rejects a missing or wrong access_key.
+    access_key_required = bool(_cfg.ACCESS_KEY)
+    if access_key_required:
+        access_key_valid = bool(
+            access_key and hmac.compare_digest(access_key, _cfg.ACCESS_KEY)
+        )
+    else:
+        access_key_valid = True   # no lock configured → everything open
     return {
         "tmdb_key_set":          bool(_cfg.SERVER_TMDB_KEY),
         "mdblist_key_set":       bool(_cfg.SERVER_MDBLIST_KEY),
         "aiostreams_configured": bool(_cfg.AIOSTREAMS_URL and _cfg.AIOSTREAMS_AUTH),
         "preset_enabled":        _cfg.PRESET_ENABLED,
         "presets":               preset_names() if _cfg.PRESET_ENABLED else [],
+        "access_key_required":   access_key_required,
+        "access_key_valid":      access_key_valid,
     }
 
 
@@ -915,9 +930,13 @@ async def readiness_probe():
 
 
 @app.get("/", response_class=HTMLResponse)
-async def get_configurator(access_key: str = ""):
-    if _cfg.ACCESS_KEY and not hmac.compare_digest(access_key, _cfg.ACCESS_KEY):
-        raise HTTPException(status_code=403, detail="Unauthorized. Provide ?access_key=<key>")
+async def get_configurator():
+    # Anonymous (Phase 11 follow-up). The configurator page itself is
+    # safe to serve to anyone: the JS detects whether the server requires
+    # an access_key and, when it does, locks every control that drives
+    # /poster output until the user enters a valid key. /poster keeps its
+    # access_key gate server-side, so this is purely a UX surface — the
+    # security boundary doesn't move.
     return HTMLResponse(content=_configurator_html or _load_configurator_html())
 
 
@@ -925,14 +944,85 @@ async def get_configurator(access_key: str = ""):
 # Search endpoint
 # ---------------------------------------------------------------------------
 
+def _gate_anonymous_tmdb_proxy(access_key: str) -> None:
+    """Phase 11 follow-up. When ACCESS_KEY is configured, /search and
+    /resolve-imdb are anonymous only if PRESET_ENABLED (i.e. the public
+    preset flow actually needs the title picker for anonymous users).
+    On instances without presets, the original access_key gate stays so
+    we don't expose the server TMDB key to unthrottled public traffic
+    against a backend that has no anonymous user-facing endpoint."""
+    if not _cfg.ACCESS_KEY:
+        return                                       # nothing gated
+    if _cfg.PRESET_ENABLED:
+        return                                       # anonymous OK
+    if access_key and hmac.compare_digest(access_key, _cfg.ACCESS_KEY):
+        return                                       # tenant key OK
+    raise HTTPException(status_code=403, detail="Unauthorized")
+
+
+async def _anonymous_tmdb_rate_limit(tmdb_key: str, access_key: str) -> None:
+    """Phase 11 follow-up. /search and /resolve-imdb are anonymous (when
+    PRESET_ENABLED) so the public preset flow can use the title picker,
+    but that means a public visitor can hit them and burn the operator's
+    server TMDB quota.
+
+    Three buckets, in priority order:
+
+      * Caller-supplied tmdb_key → per-key bucket sized by RATE_LIMIT_RPS
+        (default 0 = unlimited; caller's own TMDB quota is the backstop).
+      * Valid access_key (authenticated tenant relying on server's TMDB
+        key) → per-access-key bucket sized by RATE_LIMIT_RPS. Treats
+        each tenant as its own bucket so a noisy tenant can't drag
+        others down, but doesn't apply the anonymous floor — they paid
+        for higher throughput by authenticating.
+      * Anonymous (no tmdb_key, no valid access_key) → shared
+        "anonymous" bucket sized by ANONYMOUS_TMDB_RPS (default 5/s).
+        Independent of RATE_LIMIT_RPS so the floor applies even when
+        the operator hasn't configured a poster rate limit.
+    """
+    if tmdb_key:
+        if _cfg.RATE_LIMIT_RPS <= 0:
+            return
+        tenant_id = hashlib.sha256(tmdb_key.encode("utf-8")).hexdigest()[:16]
+        rps = _cfg.RATE_LIMIT_RPS
+    elif (
+        _cfg.ACCESS_KEY
+        and access_key
+        and hmac.compare_digest(access_key, _cfg.ACCESS_KEY)
+    ):
+        if _cfg.RATE_LIMIT_RPS <= 0:
+            return
+        tenant_id = hashlib.sha256(access_key.encode("utf-8")).hexdigest()[:16]
+        rps = _cfg.RATE_LIMIT_RPS
+    else:
+        if _cfg.ANONYMOUS_TMDB_RPS <= 0:
+            return
+        tenant_id = "anonymous"
+        rps = _cfg.ANONYMOUS_TMDB_RPS
+    allowed, retry_after = await coord.check_rate_limit(tenant_id, rps)
+    if not allowed:
+        raise HTTPException(
+            status_code=429,
+            detail=f"Rate limit exceeded ({rps} req/s)",
+            headers={"Retry-After": str(retry_after)},
+        )
+
+
 @app.get("/search")
 async def search_proxy(
     q: str,
     tmdb_key: str = "",
     access_key: str = "",
 ):
-    if _cfg.ACCESS_KEY and not hmac.compare_digest(access_key, _cfg.ACCESS_KEY):
-        raise HTTPException(status_code=403, detail="Unauthorized")
+    # Auth is conditional (Phase 11 follow-up). /search is anonymous
+    # only when the operator has opted into the public preset flow
+    # (PRESET_ENABLED), because the title picker is what populates the
+    # imdb_id for a /p URL. On instances without presets there's no
+    # anonymous user-facing flow, so the original access_key gate stays
+    # — otherwise a public visitor could burn the server TMDB quota
+    # against an instance that has no anonymous endpoint to support.
+    _gate_anonymous_tmdb_proxy(access_key)
+    await _anonymous_tmdb_rate_limit(tmdb_key, access_key)
     if len(q) > 200:
         raise HTTPException(status_code=400, detail="Query too long")
 
@@ -961,9 +1051,10 @@ async def resolve_imdb(
     tmdb_key: str = "",
     access_key: str = "",
 ):
-    if _cfg.ACCESS_KEY and not hmac.compare_digest(access_key, _cfg.ACCESS_KEY):
-        raise HTTPException(status_code=403, detail="Unauthorized")
-
+    # Pairs with /search; same conditional-auth model. Anonymous only
+    # when PRESET_ENABLED is true; otherwise the access_key gate stays.
+    _gate_anonymous_tmdb_proxy(access_key)
+    await _anonymous_tmdb_rate_limit(tmdb_key, access_key)
     _check_tmdb_id(tmdb_id)
     _check_type(type)
 

--- a/main.py
+++ b/main.py
@@ -201,7 +201,15 @@ from quality import (
     render_badges_left,
 )
 from ratings import calculate_weighted_score, draw_score_bar, fetch_rating, draw_score_bar_vertical
-from tmdb import composite_logo, fetch_logo, fetch_poster_metadata, fetch_poster_image, fetch_trending_rank
+from tmdb import (
+    composite_logo,
+    fetch_logo,
+    fetch_poster_metadata,
+    fetch_poster_image,
+    fetch_trending_rank,
+    resolve_imdb_to_tmdb,
+)
+from presets import get_preset, preset_names
 
 # ---------------------------------------------------------------------------
 # Persistent HTTP client
@@ -801,6 +809,8 @@ async def server_caps(access_key: str = ""):
         "tmdb_key_set":          bool(_cfg.SERVER_TMDB_KEY),
         "mdblist_key_set":       bool(_cfg.SERVER_MDBLIST_KEY),
         "aiostreams_configured": bool(_cfg.AIOSTREAMS_URL and _cfg.AIOSTREAMS_AUTH),
+        "preset_enabled":        _cfg.PRESET_ENABLED,
+        "presets":               preset_names() if _cfg.PRESET_ENABLED else [],
     }
 
 
@@ -1473,7 +1483,7 @@ async def get_poster(
     except httpx.TimeoutException as exc:
         if _render_fut is not None and not _render_fut.done():
             _render_fut.set_exception(exc)
-        logger.warning(f"Upstream timeout for tmdb_id={tmdb_id}: {type(exc).__name__}")
+        logger.warning(f"Upstream timeout for tmdb_id={tmdb_id}: {exc.__class__.__name__}")
         raise HTTPException(status_code=504, detail="Upstream request timed out")
     except httpx.HTTPStatusError as exc:
         if _render_fut is not None and not _render_fut.done():
@@ -1509,3 +1519,301 @@ async def get_poster(
             _rating_fetch_inflight.pop(imdb_id, None)
         if final_cache_key is not None:
             _render_inflight.pop(final_cache_key, None)
+
+
+# ---------------------------------------------------------------------------
+# Public preset endpoint (Phase 11)
+# ---------------------------------------------------------------------------
+# /p/{preset}/{type}/{imdb_id}.jpg — anonymous, CDN-cacheable, no per-user
+# keys. Six fixed presets ship in presets.py. The render pipeline is a
+# focused subset of /poster's: no MDBlist coalescing, no AIOStreams
+# background fetch, no per-tenant rate limit (operator-wide RATE_LIMIT_RPS
+# still applies via the "preset" tenant bucket).
+#
+# Rating data is used only when already cached. An uncached title renders
+# without rating on first hit and is served with a short cache-control so
+# the next request can pick up freshly-warmed rating data (warmed by the
+# next paid /poster call or a sister /p hit after PRESET_CDN_CACHE_TTL).
+# This deliberately avoids letting anonymous /p traffic burn MDBlist quota.
+
+_PRESET_ROUTE_VALID_TYPES = frozenset({"movie", "tv"})
+
+
+@app.get("/p/{preset}/{type}/{imdb_id}.jpg")
+async def get_preset_poster(
+    preset: str,
+    type: str,
+    imdb_id: str,
+):
+    if not _cfg.PRESET_ENABLED:
+        raise HTTPException(status_code=404, detail="Not found")
+
+    preset_params = get_preset(preset)
+    if preset_params is None:
+        raise HTTPException(status_code=404, detail=f"Unknown preset '{preset}'")
+
+    # Accept the configurator's `series` placeholder substitution as an
+    # alias for `tv`. The /p route's path validator only stores `movie|tv`
+    # canonically; folding here keeps copied template URLs working when
+    # AIOMetadata fills `{type}` with `series` for TV shows.
+    if type == "series":
+        type = "tv"
+    if type not in _PRESET_ROUTE_VALID_TYPES:
+        raise HTTPException(status_code=400, detail="Invalid type (movie|tv)")
+    _check_imdb_id(imdb_id)
+
+    effective_tmdb_key = _resolve_tmdb_key("")
+    if not effective_tmdb_key:
+        raise HTTPException(status_code=503, detail="Server TMDB key not configured")
+
+    # Operator-wide rate limit. All anonymous preset traffic shares the
+    # "preset" bucket so a runaway integration can't drag /poster down.
+    if _cfg.RATE_LIMIT_RPS > 0:
+        allowed, retry_after = await coord.check_rate_limit("preset", _cfg.RATE_LIMIT_RPS)
+        if not allowed:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Rate limit exceeded ({_cfg.RATE_LIMIT_RPS} req/s)",
+                headers={"Retry-After": str(retry_after)},
+            )
+
+    if _HTTP_CLIENT is None:
+        raise HTTPException(status_code=503, detail="Service unavailable")
+    client = _HTTP_CLIENT
+
+    tmdb_id = await resolve_imdb_to_tmdb(client, imdb_id, effective_tmdb_key, type)
+    if not tmdb_id:
+        raise HTTPException(status_code=404, detail="Title not found on TMDB")
+
+    raw_params = dict(preset_params)
+    rcfg = build_request_config(raw_params)
+
+    # Same cache key shape as /poster so a preset URL and an equivalent
+    # /poster URL share blobstore entries — no duplicate composites.
+    _params_hash = hashlib.md5(
+        "&".join(f"{k}={v}" for k, v in sorted(raw_params.items())).encode()
+    ).hexdigest()[:8]
+    final_cache_key = f"{imdb_id}:{type}:{_params_hash}"
+
+    # Long cache-control on cache hits; deterministic preset → deterministic URL.
+    def _preset_cache_header() -> dict:
+        ttl = _cfg.PRESET_CDN_CACHE_TTL
+        return {"Cache-Control": f"public, max-age={ttl}"} if ttl > 0 else {}
+
+    cdn_url = get_cached_final_poster_url(final_cache_key)
+    if cdn_url is not None:
+        if await is_cached_final_poster_fresh(final_cache_key):
+            logger.info(f"Preset {preset} cache hit (CDN redirect) for {final_cache_key}")
+            resp = Response(status_code=302)
+            resp.headers["Location"] = cdn_url
+            for k, v in _preset_cache_header().items():
+                resp.headers[k] = v
+            return resp
+    else:
+        cached_jpeg = await get_cached_final_poster(final_cache_key)
+        if cached_jpeg is not None:
+            logger.info(f"Preset {preset} cache hit (inline) for {final_cache_key}")
+            return Response(
+                content=cached_jpeg,
+                media_type="image/jpeg",
+                headers=_preset_cache_header(),
+            )
+
+    # Rating + quality data are used ONLY if already cached — anonymous
+    # /p traffic must not fan out into MDBlist or AIOStreams. Read both
+    # BEFORE wiring up coalescing because coalescing is only safe when
+    # we'll actually persist the composite. If either input is missing
+    # the render gets a short Cache-Control and is NOT persisted; sharing
+    # that response with waiters via _render_inflight would let them
+    # inherit the long preset TTL and poison the CDN with an incomplete
+    # poster that wouldn't refresh until PRESET_CDN_CACHE_TTL expires.
+    cached_rating = get_cached_rating(imdb_id)
+    cached_release_date = cached_rating[2] if cached_rating is not None else None
+    # NOTE: keep the None vs [] distinction. None means "never queried"
+    # (cache miss); [] means "queried, no quality tokens available for
+    # this title" — both render with no badges, but only the first
+    # should suppress persistence.
+    cached_quality = get_cached_quality(imdb_id, cached_release_date)
+    quality_tokens  = cached_quality or []
+    wants_badges    = rcfg.badge_display_mode in (1, 2)
+    quality_missing = wants_badges and cached_quality is None
+    will_persist    = cached_rating is not None and not quality_missing
+
+    # Coalesce concurrent uncached preset renders — only on the
+    # will-persist path. When inputs are incomplete each concurrent
+    # request renders independently; the duplicate work is bounded by
+    # RENDER_CONCURRENCY and the case is rare (cache warms after the
+    # first paid /poster hit).
+    _render_fut: "asyncio.Future[bytes] | None" = None
+    if will_persist:
+        _existing_fut = _render_inflight.get(final_cache_key)
+        if _existing_fut is not None:
+            logger.info(f"Preset {preset} coalescing on {final_cache_key}")
+            try:
+                return Response(
+                    content=await _existing_fut,
+                    media_type="image/jpeg",
+                    headers=_preset_cache_header(),
+                )
+            except Exception:
+                pass   # in-flight render failed; fall through and try ourselves
+        _render_fut = asyncio.get_running_loop().create_future()
+        _render_fut.add_done_callback(
+            lambda f: f.exception() if not f.cancelled() and f.exception() else None
+        )
+        _render_inflight[final_cache_key] = _render_fut
+
+    if cached_rating is not None:
+        (
+            ratings_dict, cached_genre, _cached_release_date,
+            award_wins, award_noms, _awards_fetched,
+            festival_label, age_rating,
+            is_cult, is_true_story, is_metacritic,
+        ) = cached_rating
+        effective_movie_weights = rcfg.movie_weights or _cfg.MOVIE_WEIGHTS
+        effective_tv_weights    = rcfg.tv_weights    or _cfg.TV_WEIGHTS
+        if isinstance(ratings_dict, dict):
+            weights = (
+                effective_tv_weights if type in ("tv", "series")
+                else effective_movie_weights
+            )
+            score = calculate_weighted_score(ratings_dict, weights)
+        else:
+            score = "N/A"
+        genre = cached_genre or "Unknown"
+        rel   = cached_release_date
+    else:
+        ratings_dict   = {}
+        score          = "N/A"
+        genre          = "Unknown"
+        rel            = None
+        award_wins     = []
+        award_noms     = []
+        festival_label = None
+        age_rating     = None
+        is_cult        = False
+        is_true_story  = False
+        is_metacritic  = False
+
+    try:
+        genre_ids, is_textless, logos, release_year, title, poster_path, tmdb_data = (
+            await fetch_poster_metadata(client, tmdb_id, effective_tmdb_key, type)
+        )
+
+        image, logo, trending_rank = await asyncio.gather(
+            fetch_poster_image(client, tmdb_id, type, poster_path),
+            fetch_logo(client, logos, rcfg.logo_language) if is_textless else _resolved(None),
+            fetch_trending_rank(client, tmdb_id, effective_tmdb_key, type),
+        )
+
+        discovery_meta = extract_discovery_meta(
+            tmdb_data=tmdb_data,
+            media_type=type,
+            award_wins=award_wins,
+            award_noms=award_noms,
+            trending_rank=trending_rank,
+            release_date=rel,
+            keywords=[],
+            festival_label_override=festival_label,
+            is_cult_override=is_cult,
+            is_true_story_override=is_true_story,
+            is_metacritic_override=is_metacritic,
+            is_digital_release_override=is_digital_release(imdb_id),
+        )
+
+        _bp_args = dict(
+            logo=logo if is_textless else None,
+            fallback_title=title if is_textless and not logo else None,
+            discovery_meta=discovery_meta,
+            quality_tokens=quality_tokens,
+            release_year=release_year,
+            age_rating=age_rating,
+        )
+
+        def _composite_and_encode() -> bytes:
+            result = build_poster(image, score, genre, rcfg, **_bp_args)
+            buf = io.BytesIO()
+            result.convert("RGB").save(buf, format="JPEG", quality=85)
+            return buf.getvalue()
+
+        global _render_semaphore
+        if _render_semaphore is None:
+            _render_semaphore = asyncio.Semaphore(_cfg.RENDER_CONCURRENCY)
+        try:
+            if _cfg.RENDER_QUEUE_TIMEOUT > 0:
+                await asyncio.wait_for(
+                    _render_semaphore.acquire(),
+                    timeout=_cfg.RENDER_QUEUE_TIMEOUT,
+                )
+            else:
+                await _render_semaphore.acquire()
+        except asyncio.TimeoutError:
+            _metrics.render_saturated_total.inc()
+            logger.warning(
+                f"Render queue saturated (cap={_cfg.RENDER_CONCURRENCY}); "
+                f"returning 503 for preset={preset} imdb={imdb_id}"
+            )
+            if _render_fut is not None and not _render_fut.done():
+                _render_fut.set_exception(HTTPException(status_code=503))
+            raise HTTPException(
+                status_code=503,
+                detail="Server saturated — try again shortly",
+                headers={"Retry-After": "5"},
+            )
+        try:
+            _metrics.render_inflight.inc()
+            with _metrics.render_duration_seconds.time():
+                img_bytes = await asyncio.get_running_loop().run_in_executor(
+                    None, _composite_and_encode
+                )
+        finally:
+            _metrics.render_inflight.dec()
+            _render_semaphore.release()
+
+        # Cache the composite only when the inputs that drive the render
+        # were complete (will_persist; computed once at the top so the
+        # coalesce decision and the persist decision can't drift). Either
+        # incomplete case serves the bytes with a short revalidate window
+        # so the next request picks up the warmer cache.
+        if will_persist:
+            await set_cached_final_poster(final_cache_key, img_bytes)
+            logger.info(f"Preset {preset} cached for {final_cache_key}")
+            headers = _preset_cache_header()
+        else:
+            reason = (
+                "no rating data" if cached_rating is None else "no cached quality"
+            )
+            logger.info(
+                f"Preset {preset} served uncached ({reason}) for {final_cache_key}"
+            )
+            headers = {"Cache-Control": "public, max-age=300"}   # 5-min revalidate
+
+        if _render_fut is not None:
+            _render_fut.set_result(img_bytes)
+
+        return Response(content=img_bytes, media_type="image/jpeg", headers=headers)
+
+    except httpx.TimeoutException as exc:
+        if _render_fut is not None and not _render_fut.done():
+            _render_fut.set_exception(exc)
+        logger.warning(f"Preset upstream timeout for {imdb_id}: {exc.__class__.__name__}")
+        raise HTTPException(status_code=504, detail="Upstream request timed out")
+    except httpx.HTTPStatusError as exc:
+        if _render_fut is not None and not _render_fut.done():
+            _render_fut.set_exception(exc)
+        status = exc.response.status_code
+        if status == 404:
+            _endpoint = "tv" if type in ("tv", "series") else "movie"
+            delete_cached_tmdb_metadata(f"{_endpoint}_{tmdb_id}")
+            raise HTTPException(status_code=404, detail="Poster image not found on TMDB")
+        logger.error(f"Preset upstream HTTP {status} for {imdb_id}: {exc}")
+        raise HTTPException(status_code=502, detail=f"Upstream error {status}")
+    except HTTPException:
+        raise
+    except Exception as exc:
+        if _render_fut is not None and not _render_fut.done():
+            _render_fut.set_exception(exc)
+        logger.exception(f"Error building preset poster for imdb={imdb_id} preset={preset}")
+        raise HTTPException(status_code=500, detail="Failed to build poster")
+    finally:
+        _render_inflight.pop(final_cache_key, None)

--- a/presets.py
+++ b/presets.py
@@ -1,0 +1,103 @@
+"""Phase 11: named preset bundles for the anonymous public tier.
+
+The public preset endpoint ``/p/{preset}/{type}/{imdb_id}.jpg`` resolves
+the preset name to a fixed ``raw_params`` dict, then runs the same
+render pipeline as ``/poster`` but with a few simplifications that make
+it CDN-cacheable and quota-safe:
+
+  * No per-user TMDB / MDBlist keys — the operator's server keys are used.
+  * No access_key gating — the endpoint is anonymous (the operator
+    decides whether to expose it by setting ``PRESET_ENABLED``).
+  * No active quality-badge fetch — badges only render from cached
+    AIOStreams data (``badge_display_mode=1``) so an anonymous poster
+    load can't fan out into per-title stream lookups.
+
+Presets are intentionally small and grep-able. Each value is a string
+because ``build_request_config`` parses raw query-param strings; that
+keeps the public preset path bit-for-bit equivalent to a /poster call
+with the same params.
+
+Adding a preset: append to ``PRESETS`` below, add a one-line
+description, and the new key is immediately reachable as
+``/p/<name>/...``. Keep names URL-safe lowercase + dashes.
+
+Cherry-pick guide:
+  * Upstream has no equivalent — this is an ElfHosted-only module.
+  * The preset dicts are pure data; nothing about them couples to the
+    rest of the codebase, so renaming or retuning a preset is a
+    one-file change.
+"""
+from __future__ import annotations
+
+
+# Common base applied to every preset. Public-tier defaults:
+#   * Badges from cache only (no AIOStreams fan-out per anonymous hit).
+#   * Sash on (the curated discovery overrides are the moat).
+_PUBLIC_BASE: dict[str, str] = {
+    "badge_display_mode": "1",
+    "show_award_sash":    "true",
+}
+
+
+def _preset(extra: dict[str, str]) -> dict[str, str]:
+    """Layer preset-specific overrides on top of the public-tier base."""
+    return {**_PUBLIC_BASE, **extra}
+
+
+# Six starter presets. Names are part of the URL contract — renaming a
+# preset breaks any external link that already uses it, so rename only
+# with a deprecation alias.
+PRESETS: dict[str, dict[str, str]] = {
+    # Default rendering — same look the configurator emits by default.
+    # The natural choice for embedding posters where you don't have an
+    # opinion about visual tone.
+    "default": _preset({}),
+
+    # Sash-forward. Hides the numeric score so the award/discovery sash
+    # is the dominant element. Useful for catalogues skewed toward
+    # prestige picks (festival winners, AFI lists, "best of" sets).
+    "awards": _preset({
+        "rating_display_mode": "0",
+    }),
+
+    # Minimalist mode — small genre text bottom-right, no score bar.
+    # Pairs well with grid-heavy UIs that want the poster art to lead.
+    "minimalist": _preset({
+        "rating_display_mode": "3",
+    }),
+
+    # Letterboxd-flavoured: numeric score with the genre tag, no sash.
+    # Mirrors the audience-score-only aesthetic of letterboxd embeds.
+    "letterboxd": _preset({
+        "rating_display_mode":   "2",
+        "show_award_sash":       "false",
+        "movie_weights":         "letterboxd:1.0",
+        "tv_weights":            "trakt:0.7,tomatoes:0.3",
+    }),
+
+    # Cinephile: prestige-leaning sash priority. Surfaces festival
+    # circuit and director/cast badges before commercial-success ones
+    # like "trending" or "metacritic-must-see".
+    "cinephile": _preset({
+        "rating_display_mode": "1",
+        "sash_priority":       "wins,festival,gg_wins,director,cast,studio,pic_noms,gg_noms",
+    }),
+
+    # Quality-forward: keeps the score visible AND the quality badges
+    # corner-stacked when AIOStreams data is in cache. Good for users
+    # who want stream-availability cues alongside the poster.
+    "quality": _preset({
+        "rating_display_mode": "1",
+        "badge_display_mode":  "1",
+    }),
+}
+
+
+def get_preset(name: str) -> dict[str, str] | None:
+    """Return the raw_params dict for a preset name, or None if unknown."""
+    return PRESETS.get(name)
+
+
+def preset_names() -> list[str]:
+    """List of registered preset names — used by /server-caps for discovery."""
+    return sorted(PRESETS.keys())

--- a/run-local.py
+++ b/run-local.py
@@ -1,0 +1,30 @@
+"""Local dev runner. Patches the hardcoded /app/cache paths in config to
+point at a writable directory under the project, so the app boots on
+macOS/Linux without needing the container's /app filesystem layout.
+
+Usage:  PRESET_ENABLED=true .venv/bin/python run-local.py
+"""
+import os
+import config
+
+ROOT = os.path.dirname(os.path.abspath(__file__))
+LOCAL_CACHE = os.path.join(ROOT, ".local-cache")
+os.makedirs(LOCAL_CACHE, exist_ok=True)
+
+config.DB_PATH               = os.path.join(LOCAL_CACHE, "cache.db")
+config.TMDB_POSTER_CACHE_DIR = os.path.join(LOCAL_CACHE, "tmdb_posters")
+config.TMDB_LOGO_CACHE_DIR   = os.path.join(LOCAL_CACHE, "tmdb_logos")
+config.COMPOSITE_BLOB_DIR    = os.path.join(LOCAL_CACHE, "composites")
+config.BADGE_DIR             = os.path.join(ROOT, "badges")
+
+os.environ.setdefault("PROMETHEUS_MULTIPROC_DIR", os.path.join(LOCAL_CACHE, "prom"))
+_prom_dir = os.environ["PROMETHEUS_MULTIPROC_DIR"]
+os.makedirs(_prom_dir, exist_ok=True)
+# Mirror the container entrypoint: clear stale *.db files from prior runs
+# so /metrics doesn't aggregate counters from dead processes.
+for _f in os.listdir(_prom_dir):
+    if _f.endswith(".db"):
+        os.remove(os.path.join(_prom_dir, _f))
+
+import uvicorn
+uvicorn.run("main:app", host="127.0.0.1", port=8000, reload=False, workers=1)

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -1,0 +1,51 @@
+# Posters+
+
+> Stremio poster addon. Overlays weighted ratings (IMDB, Rotten Tomatoes, Letterboxd, Metacritic, Trakt, MyAnimeList), award sashes (Oscar, Emmy, Golden Globe, Cannes, festival winners) and quality badges (4K, 1080p, HDR, Dolby Vision, Remux) onto Stremio movie and TV posters. Alternative to BetterPosters, Rating Poster Database (RPDB), and AIOratings — designed as a Cinemeta-replacement poster source for Stremio addons that consume custom poster URL patterns (notably AIOMetadata).
+
+Posters+ runs in two postures:
+
+- **Public hosted** (this instance): anonymous, preset-only. Six fixed visual presets reachable at `/p/{preset}/{type}/{imdb_id}.jpg`. Free.
+- **Private managed**: full per-poster customisation (sliders, weights, sash priority, language, logo controls). Available via ElfHosted.
+- **Self-host**: the upstream open-source project is on GitHub.
+
+## Endpoints
+
+- `GET /p/{preset}/{type}/{imdb_id}.jpg` — anonymous preset URL. `preset` is one of: default, awards, minimalist, letterboxd, cinephile, quality. `type` is `movie` or `tv`. CDN-cacheable, no per-user keys.
+- `GET /poster?...` — full per-poster configuration via query params. Requires `access_key` on instances with `ACCESS_KEY` configured.
+- `GET /server-caps` — instance capability report (which keys are configured, whether presets are enabled, preset list).
+
+## Presets
+
+| Name         | Look                                                        |
+| ------------ | ----------------------------------------------------------- |
+| default      | Standard rendering — score bar, genre, sash if applicable.  |
+| awards       | Sash-forward — score hidden, prestige sash dominates.       |
+| minimalist   | Small genre text bottom-right, no score bar.                |
+| letterboxd   | Numeric score weighted to Letterboxd, no sash.              |
+| cinephile    | Prestige sash priority (festival before commercial).        |
+| quality      | Score visible + cached quality badges (4K, HDR, etc).       |
+
+## Rating sources
+
+Posters+ aggregates from MDBList (IMDB, Rotten Tomatoes, Letterboxd, Metacritic, Trakt, Roger Ebert, MyAnimeList, TMDB) and renders a weighted composite score. Award and festival data come from the same MDBList payload plus an ElfHosted-curated discovery overrides dataset on private instances.
+
+## Differentiators vs other Stremio poster addons
+
+- **Weighted score** rather than per-source individual ratings. The exposed score is a function of the chosen weights per source.
+- **Discovery sashes**: festival winners (Cannes Palme d'Or, Venice Golden Lion, Berlin Golden Bear, Sundance, TIFF), notable studios (A24, Studio Ghibli, Neon, etc.), notable directors, notable cast.
+- **Public CDN tier**: anonymous, cache-friendly URLs at `/p/...` so the public instance scales to high traffic without per-user state.
+
+## Related ElfHosted services
+
+- [Best Stremio Addons guide](https://stremio-addons-guide.elfhosted.com/) — curated reviews of Stremio addons, hosted by ElfHosted.
+- [ElfHosted store](https://store.elfhosted.com) — managed private instances of Posters+ and other open-source apps.
+- [Stremio Addons Guide (docs)](https://docs.elfhosted.com/stremio-addons/guide/) — full ElfHosted Stremio documentation.
+
+## Source
+
+- Upstream open-source project: <https://github.com/UmbraProjects/PostersPlus>
+- ElfHosted fork (hosting-mode resilience — Postgres, Redis, S3, multi-process metrics, per-tenant rate limiting, preset endpoint): <https://github.com/elfhosted/PostersPlus>
+
+## License
+
+MIT (upstream). ElfHosted fork inherits the same.

--- a/storage/__init__.py
+++ b/storage/__init__.py
@@ -43,6 +43,8 @@ _PUBLIC_API = (
     "is_digital_release",
     "count_digital_releases",
     "add_digital_releases",
+    "get_cached_imdb_to_tmdb",
+    "set_cached_imdb_to_tmdb",
 )
 
 

--- a/storage/postgres_backend.py
+++ b/storage/postgres_backend.py
@@ -150,6 +150,16 @@ def _bootstrap_schema(conn) -> None:
                 posted_at BIGINT NOT NULL
             )
         """)
+        # Phase 11: imdb_id -> tmdb_id mapping for the preset endpoint.
+        # No TTL — these mappings are effectively permanent.
+        cur.execute("""
+            CREATE TABLE IF NOT EXISTS imdb_to_tmdb_cache (
+                imdb_id    TEXT NOT NULL,
+                media_type TEXT NOT NULL,
+                tmdb_id    TEXT NOT NULL,
+                PRIMARY KEY (imdb_id, media_type)
+            )
+        """)
     conn.commit()
 
 
@@ -764,6 +774,40 @@ def add_digital_releases(entries: list[tuple[str, int]]) -> int:
     except Exception as exc:
         logger.error(f"Digital release cache write error: {exc}")
     return inserted
+
+
+def get_cached_imdb_to_tmdb(imdb_id: str, media_type: str) -> str | None:
+    """Phase 11: look up the cached tmdb_id for an imdb_id + media_type."""
+    try:
+        with _get_pool().connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    "SELECT tmdb_id FROM imdb_to_tmdb_cache "
+                    "WHERE imdb_id = %s AND media_type = %s",
+                    (imdb_id, media_type),
+                )
+                row = cur.fetchone()
+                return row[0] if row else None
+    except Exception as exc:
+        logger.error(f"imdb_to_tmdb cache read error: {exc}")
+        return None
+
+
+def set_cached_imdb_to_tmdb(imdb_id: str, media_type: str, tmdb_id: str) -> None:
+    try:
+        with _get_pool().connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    """
+                    INSERT INTO imdb_to_tmdb_cache (imdb_id, media_type, tmdb_id)
+                    VALUES (%s, %s, %s)
+                    ON CONFLICT (imdb_id, media_type) DO UPDATE SET tmdb_id = EXCLUDED.tmdb_id
+                    """,
+                    (imdb_id, media_type, tmdb_id),
+                )
+            conn.commit()
+    except Exception as exc:
+        logger.error(f"imdb_to_tmdb cache write error: {exc}")
 
 
 def ping() -> bool:

--- a/storage/sqlite_backend.py
+++ b/storage/sqlite_backend.py
@@ -184,6 +184,19 @@ def init_db() -> None:
         )
     """)
 
+    # Phase 11: imdb_id -> tmdb_id mapping. Used by the preset endpoint
+    # (/p/{preset}/{type}/{imdb_id}.jpg) to avoid a TMDB /find call on
+    # every public hit. The mapping is effectively immutable, so there's
+    # no TTL — entries live for the lifetime of the cache.
+    _db_conn.execute("""
+        CREATE TABLE IF NOT EXISTS imdb_to_tmdb_cache (
+            imdb_id    TEXT NOT NULL,
+            media_type TEXT NOT NULL,
+            tmdb_id    TEXT NOT NULL,
+            PRIMARY KEY (imdb_id, media_type)
+        )
+    """)
+
     existing_meta_cols = {
         row[1]
         for row in _db_conn.execute("PRAGMA table_info(tmdb_metadata_cache)").fetchall()
@@ -869,6 +882,31 @@ def add_digital_releases(entries: list[tuple[str, int]]) -> int:
     except Exception as exc:
         logger.error(f"Digital release cache write error: {exc}")
     return inserted
+
+
+def get_cached_imdb_to_tmdb(imdb_id: str, media_type: str) -> str | None:
+    """Phase 11: look up the cached tmdb_id for an imdb_id + media_type."""
+    try:
+        row = get_db().execute(
+            "SELECT tmdb_id FROM imdb_to_tmdb_cache WHERE imdb_id = ? AND media_type = ?",
+            (imdb_id, media_type),
+        ).fetchone()
+        return row[0] if row else None
+    except Exception as exc:
+        logger.error(f"imdb_to_tmdb cache read error: {exc}")
+        return None
+
+
+def set_cached_imdb_to_tmdb(imdb_id: str, media_type: str, tmdb_id: str) -> None:
+    try:
+        with _db_lock:
+            get_db().execute(
+                "INSERT OR REPLACE INTO imdb_to_tmdb_cache (imdb_id, media_type, tmdb_id) VALUES (?, ?, ?)",
+                (imdb_id, media_type, tmdb_id),
+            )
+            get_db().commit()
+    except Exception as exc:
+        logger.error(f"imdb_to_tmdb cache write error: {exc}")
 
 
 def ping() -> bool:

--- a/tmdb.py
+++ b/tmdb.py
@@ -19,6 +19,8 @@ from cache import (
     set_cached_tmdb_logo,
     get_cached_tmdb_metadata,
     set_cached_tmdb_metadata,
+    get_cached_imdb_to_tmdb,
+    set_cached_imdb_to_tmdb,
 )
 
 from config import (
@@ -192,6 +194,46 @@ async def fetch_poster_metadata(
     }
 
     return genre_ids, is_textless, logos, release_year, title, poster_path, tmdb_data
+
+
+async def resolve_imdb_to_tmdb(
+    client: httpx.AsyncClient,
+    imdb_id: str,
+    tmdb_key: str,
+    media_type: str = "movie",
+) -> str | None:
+    """Phase 11: resolve an imdb_id (tt...) to a TMDB id for the given media
+    type. Cached forever — TMDB ids are stable. Returns None on miss.
+
+    Public preset URLs only carry the imdb_id (the universal Stremio
+    identifier); this resolver runs once per (imdb_id, media_type) and
+    every subsequent /p hit reads from cache.
+    """
+    cached = get_cached_imdb_to_tmdb(imdb_id, media_type)
+    if cached is not None:
+        return cached
+
+    endpoint = "tv_results" if media_type in ("tv", "series") else "movie_results"
+    url = f"https://api.themoviedb.org/3/find/{imdb_id}"
+    try:
+        resp = await client.get(url, params={"api_key": tmdb_key, "external_source": "imdb_id"})
+        resp.raise_for_status()
+        data = resp.json()
+    except httpx.HTTPError as exc:
+        logger.warning(f"imdb_to_tmdb resolve failed for {imdb_id}: {exc}")
+        return None
+
+    results = data.get(endpoint) or []
+    if not results:
+        logger.info(f"imdb_to_tmdb: no {media_type} match for {imdb_id}")
+        return None
+
+    tmdb_id = str(results[0].get("id") or "")
+    if not tmdb_id:
+        return None
+
+    set_cached_imdb_to_tmdb(imdb_id, media_type, tmdb_id)
+    return tmdb_id
 
 
 async def fetch_poster_image(


### PR DESCRIPTION
## Summary

- New `/p/{preset}/{type}/{imdb_id}.jpg` route for the anonymous public tier — six fixed visual presets, server-side `imdb_id → tmdb_id` resolution (cached forever), focused render pipeline that never fans out to MDBlist or AIOStreams.
- `cfg-preset` toggle in the configurator emits the short `/p/...` URL form; `/server-caps` advertises `preset_enabled` so the selector is hidden when the backend has `PRESET_ENABLED=false`.
- Cache key is identical to `/poster`'s, so an equivalent /poster + /p hit share one composite blob.

Operator switches (default off): `PRESET_ENABLED=true`, `PRESET_CDN_CACHE_TTL=86400`.

Five P2 issues caught + fixed across four codex-review passes; pass 5 clean. Detail in [RESILIENCE.md "Phase 11 — reviewed"](RESILIENCE.md).

## Test plan

- [ ] Local syntax: `python3 -m ast` on all touched Python files
- [ ] Local syntax: JS in configurator.html parses via `new Function(js)`
- [ ] `PRESET_ENABLED=false` → /p returns 404; configurator dropdown is hidden
- [ ] `PRESET_ENABLED=true` + cached rating + cached quality → /p returns 200 jpeg with `max-age=PRESET_CDN_CACHE_TTL`
- [ ] /p without cached rating → 200 jpeg with `max-age=300`, not persisted
- [ ] /p with cached rating but `quality_missing` → same short-TTL path
- [ ] /p with `OBJECT_STORE_PUBLIC_URL` set and a cached composite → 302 to CDN
- [ ] Configurator import of a `/p/awards/movie/tt0111161.jpg` URL → preset dropdown populated, preview loads
- [ ] Configurator import of a custom /poster URL after preset mode → resets `cfg-preset` to Custom, URL rebuilds as /poster

🤖 Generated with [Claude Code](https://claude.com/claude-code)