### PR TITLE
fix: point store CTA at the Posters+ product page

### DIFF
--- a/configurator.html
+++ b/configurator.html
@@ -58,7 +58,7 @@
     {
       "@type": "Offer",
       "name": "Private managed instance",
-      "url": "https://store.elfhosted.com?utm_source=postersplus&utm_medium=jsonld&utm_campaign=offer_private",
+      "url": "https://store.elfhosted.com/product/posters-plus?utm_source=postersplus&utm_medium=jsonld&utm_campaign=offer_private",
       "description": "Managed private deployment with full per-poster customisation (sliders, weights, sash priority)."
     }
   ],
@@ -1445,7 +1445,7 @@
   <h2>More options</h2>
   <ul>
     <li>
-      <strong><a href="https://store.elfhosted.com?utm_source=postersplus&amp;utm_medium=noscript&amp;utm_campaign=noscript_store">Get a private instance</a></strong>
+      <strong><a href="https://store.elfhosted.com/product/posters-plus?utm_source=postersplus&amp;utm_medium=noscript&amp;utm_campaign=noscript_store">Get a private instance</a></strong>
       — managed by ElfHosted, full per-poster customisation (sliders,
       weights, sash priority).
     </li>
@@ -1513,7 +1513,7 @@
     </div>
     <div class="lock-banner-cta-row">
       <a class="lock-banner-cta primary"
-         href="https://store.elfhosted.com?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_store"
+         href="https://store.elfhosted.com/product/posters-plus?utm_source=postersplus&utm_medium=configurator&utm_campaign=lock_banner_store"
          target="_blank" rel="noopener noreferrer">
         <span class="lock-banner-cta-label">Get a private instance</span>
         <span class="lock-banner-cta-sub">$1 trial</span>

--- a/static/llms.txt
+++ b/static/llms.txt
@@ -38,7 +38,7 @@ Posters+ aggregates from MDBList (IMDB, Rotten Tomatoes, Letterboxd, Metacritic,
 ## Related ElfHosted services
 
 - [Best Stremio Addons guide](https://stremio-addons-guide.elfhosted.com/) — curated reviews of Stremio addons, hosted by ElfHosted.
-- [ElfHosted store](https://store.elfhosted.com) — managed private instances of Posters+ and other open-source apps.
+- [Posters+ on the ElfHosted store](https://store.elfhosted.com/product/posters-plus) — managed private instance of Posters+ with full per-poster customisation.
 - [Stremio Addons Guide (docs)](https://docs.elfhosted.com/stremio-addons/guide/) — full ElfHosted Stremio documentation.
 
 ## Source


### PR DESCRIPTION
## Summary

Repoint all four \`store.elfhosted.com\` references at the specific product URL — sends visitors straight to the Posters+ subscription instead of the store landing page.

- Lock-banner CTA (visible)
- \`<noscript>\` fallback link
- JSON-LD \`Offer.url\`
- \`static/llms.txt\` store reference

UTM tags preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)