### PR TITLE
fix: cherry-pick upstream crash fix when no rating data (e26d204)

### DIFF
--- a/ratings.py
+++ b/ratings.py
@@ -135,6 +135,8 @@ def draw_score_bar(
     glow_blur: int = SCORE_GLOW_BLUR,
     glow_alpha: int = SCORE_GLOW_ALPHA,
 ) -> None:
+    if score is None:
+        return
     if isinstance(score, str):
         try:
             score = int(score)
@@ -227,6 +229,8 @@ def draw_score_bar_vertical(
     height: int = 36,
     width: int = 4,
 ) -> None:
+    if score is None:
+        return
     if isinstance(score, str):
         try:
             score = int(score)


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [\`e26d204\`](https://github.com/UmbraProjects/PostersPlus/commit/e26d204b8c8a576a7e9001165737949d5c4db9e6) — fixes a TypeError in \`draw_score_bar\` / \`draw_score_bar_vertical\` when score is None (no MDBList key, no weighted sources available). Original commit message + co-author preserved.

Applies cleanly to our fork — 4-line addition to \`ratings.py\` only, no conflict.

## Upstream alignment

This is one of 14 upstream commits since our fork point. The rest are categorised in chat:
- Docker/CI commits (7) — skip; we have our own pipeline
- README/showcase commits (4) — skip; fork-specific README
- Configurator URL guidance (\`ebcddd4\`) — skip; our README diverges
- Feature bundle \`6a4a2ea\` (quality tier bar / score palettes / muted sash / textless toggle / no-poster fallback) — **defer to a separate feature-merge PR** because it touches 14 files with heavy conflict risk against our \`main.py\` and \`configurator.html\` work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)