### PR TITLE
feat: port upstream visual-features bundle (6a4a2ea) + retune presets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,10 @@ QUALITY_BG_CONCURRENCY=5
 # Set to 0 to disable (default; recommended unless you're using a CDN).
 CDN_CACHE_TTL=0
 
+# JPEG output quality for composited posters (70–95). Higher = larger files.
+# Default: 85. Raise to 92 for pixel-peepers; lower to 75 to reduce storage/bandwidth.
+JPEG_QUALITY=85
+
 # Seconds to keep a composited poster before re-rendering.
 # Default: 604800 (7 days)
 # Pruning happens automatically based on this value to avoid an evergrowing cache of dead content when users abandon configs

--- a/RESILIENCE.md
+++ b/RESILIENCE.md
@@ -734,3 +734,54 @@ User direction: drop the access-key unlock UI entirely. "Users wanting more cust
 5. **Pass 5 clean.**
 
 Re-design ready to merge.
+
+### Upstream port — 6a4a2ea (visual features bundle)
+
+Brought in upstream commit [`6a4a2ea`](https://github.com/UmbraProjects/PostersPlus/commit/6a4a2ea08ea407bf5b265fbab5be845f086c4809): mode 4 tier accent bar, three score colour palettes (default / six-band / metal), muted sash, textless logo toggle, no-poster fallback canvas, JPEG_QUALITY config, ETag/304 handling on /poster cache hits, ?debug=1 diagnostic JSON, plus assorted privacy/log fixes.
+
+Other upstream commits skipped (CI/build workflows, README/showcase content, dockerfile gosu rework — all fork-divergent territory).
+
+Hand-resolved conflicts:
+
+- `main.py` cache-hit branch — merged upstream's ETag + 304 into our Phase 10 CDN-redirect + inline structure.
+- `configurator.html` header — kept the ElfHosted brand block; rejected upstream's GitHub-icon-only header.
+
+Extensions on top of the upstream patch:
+
+- Ported the no-poster fallback into the `/p` preset endpoint too (upstream only patched `/poster`).
+- Fixed a duplicate `except ValueError` block upstream had emitted.
+- Updated `/p`'s `wants_badges` guard to include mode 4 — without it the new public-tier default would persist grey "worst tier" bars when quality wasn't yet cached.
+
+Six codex passes to clean. Findings + fixes (all our porting issues, none surfaced in the upstream commit on its own):
+
+1. **[P2]** /p quality guard didn't include mode 4 → grey-tier renders would persist for 24h. Added mode 4 to the guard.
+2. **[P2]** 304 was returned before validating cache freshness → stale ETags could pin clients to expired content. Now we pull cached bytes first; if missing/expired, fall through to re-render.
+3. **[P2]** `?debug=1` could be intercepted by cache hits, returning JPEG instead of diagnostic JSON. Moved the debug check above the cache lookup; debug requests skip cache and don't persist.
+4. **[P2]** Mode 4 rendered a grey "worst tier" bar with empty quality tokens, misrepresenting "unknown" as "bad". Now skips the bar entirely when tokens are empty.
+5. **[P2]** /poster emitted a stable ETag + long Cache-Control on quality-pending transient renders. Both now suppressed for transient renders; short 5-min revalidate window so warmed cache surfaces on the next hit.
+6. **[P2]** Coalesce path also emitted long Cache-Control on potentially-transient renders. Short TTL + no ETag on coalesced responses (the future doesn't carry the leader's transient flag).
+7. **[P2]** Debug JSON crashed with `int(None)` when score was None. Handles None explicitly now.
+8. **[P3]** `textless=true` still fetched the logo PNG before discarding it. fetch_logo skipped when `rcfg.textless`.
+9. **[P2]** Mode 4 glow composite raised ValueError when badge anchors were near 0 (off-canvas dest). Crops the glow layer to the visible region before compositing.
+
+### Preset re-evaluation (post-upstream-port)
+
+With the new render-cheap features (mode 4 tier bar, muted sash, textless toggle, metal palette), I revisited the six presets against the goals of:
+
+- bounded cache cardinality (still 6 distinct `params_hash` values per `(imdb_id, type)`)
+- protected render budget (mode 4 is materially cheaper than the old mode 1 age-rating numeral or mode 2 badge row)
+
+Public base default changed: `badge_display_mode` 1→4. Per-preset changes:
+
+| Preset | Change | Why |
+| --- | --- | --- |
+| `default` | inherits mode 4 from base | Cheaper render than the old age-rating numeral |
+| `awards` | + `badge_display_mode=0`, `muted=true` | Sash truly dominates; muted sash sits in the art not above it |
+| `minimalist` | + `badge_display_mode=0`, `show_award_sash=false`, `textless=true` | Cheapest preset to render — pure poster art with tiny genre tag |
+| `letterboxd` | + `badge_display_mode=0` | Letterboxd aesthetic is score-only, no quality clutter |
+| `cinephile` | + `muted=true`, `score_color_mode=2` (metal) | Metal palette pairs with prestige sash priority; muted sash matches |
+| `quality` | `badge_display_mode` 1→4 | Cheaper than mode 2 row, same "stream quality at a glance" intent |
+
+Net: same six preset names (URL contract preserved), same cache cardinality, but the average render is materially cheaper. Anonymous traffic hits the cheaper modes.
+
+Port ready to merge.

--- a/age_badge.py
+++ b/age_badge.py
@@ -54,19 +54,19 @@ _TIERS = {
     "grey": {
         "glow":      (100, 100, 104,  28),   # barely any halo — looks flat/unlit
         "shadow":    (12,  12,  14, 190),
-        "primary":   (130, 130, 136, 175),   # noticeably darker and more faded than silver
+        "primary":   (130, 130, 136, 75),   # noticeably darker and more faded than silver
         "highlight": (160, 160, 166,  18),   # near-invisible — no metallic sheen
     },
     "bronze": {
         "glow":      (200, 110,  40,  70),
         "shadow":    (45,  18,   0, 210),
-        "primary":   (200, 110,  45, 225),
+        "primary":   (200, 110,  45, 125),
         "highlight": (255, 200, 150, 45),
     },
     "silver": {
         "glow":      (195, 205, 228,  65),
         "shadow":    (30,  34,  50, 215),
-        "primary":   (218, 224, 240, 200),
+        "primary":   (218, 224, 240, 125),
         "highlight": (255, 255, 255, 55),
     },
     "gold": {
@@ -150,7 +150,7 @@ def draw_quality_age_badge(
       4. Highlight pass         — near-white overlay at low opacity, shifted
                                   slightly up-left, for an inner-light illusion
     """
-    if not age_rating:
+    if age_rating is None:
         return
 
     W, H   = image.size
@@ -210,4 +210,89 @@ def draw_quality_age_badge(
     )
     # Tiny blur so the highlight blends rather than creating a visible echo
     hl_layer = hl_layer.filter(ImageFilter.GaussianBlur(max(1, font_size // 30)))
+    image.alpha_composite(hl_layer)
+
+
+# ---------------------------------------------------------------------------
+# Mode 4 — Accent bar
+# ---------------------------------------------------------------------------
+# A small vertical rounded pill in the top-left corner whose colour reflects
+# the quality tier.  No text — purely decorative / at-a-glance indicator.
+#
+# Visual layers (back → front):
+#   1. Wide ambient glow  — soft blur matching the numeral badge style
+#   2. Bar body           — solid fill at the primary tier colour
+#   3. Highlight pass     — near-white overlay at low opacity across the left
+#                           half, giving a subtle sheen without looking fake
+
+def draw_tier_bar(
+    image: Image.Image,
+    quality_tokens: Sequence[str],
+    *,
+    anchor_x_ratio: float = 0.040,
+    anchor_y_ratio: float = 0.030,
+    bar_w_ratio: float = 0.008,   # bar width as fraction of poster width (narrow)
+    bar_h_ratio: float = 0.028,   # bar height as fraction of poster height (tall)
+    min_bar_w: int = 3,
+    min_bar_h: int = 20,
+    bar_height: int | None = None,  # explicit pixel height; overrides bar_h_ratio when set
+) -> None:
+    """
+    Render a small vertical rounded accent pill in the top-left corner whose
+    fill colour reflects the quality tier derived from *quality_tokens*.
+    When *bar_height* is provided it is used directly as the bar's pixel height,
+    allowing the configurator's Height control to apply to mode 4.
+    """
+    pts    = _score_points(quality_tokens)
+    colors = _tier(pts)
+
+    W, H = image.size
+    x = int(W * anchor_x_ratio)
+    y = int(H * anchor_y_ratio)
+    bw = max(min_bar_w, int(W * bar_w_ratio))
+    bh = bar_height if bar_height is not None else max(min_bar_h, int(H * bar_h_ratio))
+    radius = bw // 2  # pill-shaped: radius driven by the narrow dimension
+
+    # ── 1. Ambient glow ───────────────────────────────────────────────────
+    pad        = bw * 5
+    glow_size  = (bw + pad * 2, bh + pad * 2)
+    glow_layer = Image.new("RGBA", glow_size, (0, 0, 0, 0))
+    ImageDraw.Draw(glow_layer).rounded_rectangle(
+        [pad, pad, pad + bw, pad + bh],
+        radius=radius,
+        fill=(*colors["glow"][:3], min(255, colors["glow"][3] + 20)),
+    )
+    glow_layer = glow_layer.filter(ImageFilter.GaussianBlur(bw * 1.8))
+    # Clamp the destination to non-negative coords — small badge anchors
+    # (the configurator allows down to 0.01) put `x - pad` / `y - pad`
+    # off the top/left edge of the canvas, which Pillow rejects with a
+    # ValueError. When that happens, crop the glow layer by the
+    # overhanging amount so the visible portion still composites.
+    gx, gy = x - pad, y - pad
+    crop_l = max(0, -gx)
+    crop_t = max(0, -gy)
+    if crop_l or crop_t:
+        glow_layer = glow_layer.crop((crop_l, crop_t, glow_layer.width, glow_layer.height))
+        gx += crop_l
+        gy += crop_t
+    image.alpha_composite(glow_layer, dest=(gx, gy))
+
+    # ── 2. Bar body ───────────────────────────────────────────────────────
+    bar_layer = Image.new("RGBA", image.size, (0, 0, 0, 0))
+    ImageDraw.Draw(bar_layer).rounded_rectangle(
+        [x, y, x + bw, y + bh],
+        radius=radius,
+        fill=colors["primary"],
+    )
+    image.alpha_composite(bar_layer)
+
+    # ── 3. Highlight sheen ────────────────────────────────────────────────
+    # Fill only the left half of the bar to simulate light catching the edge.
+    hl_layer = Image.new("RGBA", image.size, (0, 0, 0, 0))
+    hl_w = max(1, bw // 2)
+    ImageDraw.Draw(hl_layer).rounded_rectangle(
+        [x, y, x + hl_w, y + bh],
+        radius=radius,
+        fill=(*colors["highlight"][:3], min(255, colors["highlight"][3] + 20)),
+    )
     image.alpha_composite(hl_layer)

--- a/awards.py
+++ b/awards.py
@@ -1215,6 +1215,7 @@ def draw_award_sash(
     image: Image.Image,
     label: str,
     sash_type: str = "win",
+    muted: bool = False,
 ) -> Image.Image:
     width, height = image.size
 
@@ -1283,6 +1284,13 @@ def draw_award_sash(
 
     sash = sash.rotate(-45, expand=True, resample=Image.Resampling.BICUBIC)
     sash = sash.resize((sash.width // SS, sash.height // SS), Image.Resampling.LANCZOS)
+
+    if muted:
+        # Scale alpha to ~85% — sits level with the art rather than above it,
+        # without making the text hard to read.
+        r, g, b, a = sash.split()
+        a = a.point(lambda v: int(v * 0.8))
+        sash = Image.merge("RGBA", (r, g, b, a))
 
     shadow   = Image.new("RGBA", sash.size, (0, 0, 0, 0))
     sd       = ImageDraw.Draw(shadow)

--- a/config.py
+++ b/config.py
@@ -95,6 +95,8 @@ RATE_LIMIT_RPS          = int(os.environ.get("RATE_LIMIT_RPS", "0"))
 # Cache-Control: public header so Cloudflare (or any CDN) caches them at the
 # edge. Set to 0 to disable (e.g. when running without a CDN).
 CDN_CACHE_TTL         = int(os.environ.get("CDN_CACHE_TTL", "0"))
+# JPEG output quality for composited posters (70–95). Higher = better quality, larger files.
+JPEG_QUALITY          = max(70, min(95, int(os.environ.get("JPEG_QUALITY", "85"))))
 
 # Phase 11: public preset endpoint (/p/{preset}/{type}/{imdb_id}.jpg).
 # When PRESET_ENABLED is true, anonymous requests can hit a small set of
@@ -122,7 +124,7 @@ SHOW_RATING_DISPLAY_MODE = 1
 SHOW_AWARD_SASH          = True
 BADGE_DISPLAY_MODE = 2
 
-# Poster Dimensions
+# Poster Dimensions (500x750)
 
 POSTER_WIDTH  = 500
 POSTER_HEIGHT = 750

--- a/configurator.html
+++ b/configurator.html
@@ -216,7 +216,7 @@
 
   /* ElfHosted brand block — right-aligned in the header beside the
      POSTERS+ logo. Matches the existing mono + caps + gold/silver-dim
-     aesthetic; SVG icon scales with the surrounding text. */
+     aesthetic. */
   .header-right {
     display: flex;
     align-items: center;
@@ -1312,7 +1312,9 @@
     .preview-panel { width: 100%; }
     .preview-frame { height: auto; min-height: 240px; padding: 12px; }
     .preview-poster { width: 100%; height: auto; max-height: 70vh; object-fit: contain; }
-    .header { flex-direction: column; align-items: flex-start; gap: 14px; }
+    .header { flex-direction: row; align-items: center; }
+    .logo-sep, .logo-sub { display: none; }
+    .header-github { opacity: 0.6; margin-top: 0; }
     .two-col, .inline-grid { grid-template-columns: 1fr; }
     .weight-item { grid-template-columns: 96px 1fr 38px; column-gap: 8px; }
     .btn-row { flex-wrap: wrap; }
@@ -1700,6 +1702,16 @@
                 <option value="3">3. Minimalist</option>
               </select>
             </div>
+            <div id="rating-alt-colors-toggle" style="margin-bottom:14px;">
+              <div class="field">
+                <label class="field-label">Colour Palette</label>
+                <select id="cfg-score-color-mode" onchange="build(); queuePreviewReload()">
+                  <option value="0">Default - red, yellow, green, purple</option>
+                  <option value="1">Dark/light - red, yellow, green</option>
+                  <option value="2">Metal - grey, bronze, silver, gold</option>
+                </select>
+              </div>
+            </div>
             <div id="rating-mode1-fields">
               <div class="field">
                 <label class="field-label">Font Size</label>
@@ -1789,6 +1801,15 @@
             <span class="section-chevron">▼</span>
           </div>
           <div class="section-body">
+            <div class="toggle-row" style="margin-bottom:14px;">
+              <div>
+                <div class="toggle-label">Textless</div>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="tog-textless" onchange="build(); queuePreviewReload()">
+                <div class="toggle-track"><div class="toggle-thumb"></div></div>
+              </label>
+            </div>
             <div class="field">
               <label class="field-label">Max Width Ratio</label>
               <div class="range-row">
@@ -1830,6 +1851,16 @@
                 <div class="toggle-track"><div class="toggle-thumb"></div></div>
               </label>
             </div>
+            <div class="toggle-row" style="margin-bottom:14px;">
+              <div>
+                <div class="toggle-label">Muted Sashes</div>
+                <div class="field-hint">Reduce sash opacity slightly.</div>
+              </div>
+              <label class="toggle-switch">
+                <input type="checkbox" id="tog-muted" onchange="build(); queuePreviewReload()">
+                <div class="toggle-track"><div class="toggle-thumb"></div></div>
+              </label>
+            </div>
             <div class="field-hint" style="margin-bottom:10px;">Drag to reorder. Click ✕ to disable a sash — the first matching sash wins.</div>
             <div class="sash-list" id="sash-priority-list"></div>
           </div>
@@ -1847,12 +1878,16 @@
               <label class="field-label">Display Mode</label>
               <select id="cfg-badge-display-mode" onchange="updateBadgeModeHint(); build(); queuePreviewReload()">
                 <option value="0">0. Hidden</option>
-                <option value="1" selected>1. Quality Age Rating</option>
+                <option value="1">1. Quality Age Rating</option>
                 <option value="2">2. Quality Badge Row</option>
                 <option value="3">3. Age Rating Only</option>
+                <option value="4" selected>4. Tier Accent Bar</option>
               </select>
               <div class="field-hint" id="badge-mode1-hint">
                 The color of the font reflects stream quality, following medal tiers.
+              </div>
+              <div class="field-hint" id="badge-mode4-hint" style="display:none">
+                Medal colored marker based on stream quality.
               </div>
               <div class="field-hint" id="badge-quality-fetch-hint" style="display:none">
                 If media quality is un-cached, it's fetched in the background and applied for future requests.
@@ -1864,9 +1899,9 @@
             <div class="two-col">
               <div class="field">
                 <label class="field-label">Height (px)</label>
-                <input type="number" id="cfg-badge-h" value="36" min="16" max="80" oninput="build(); queuePreviewReload()">
+                <input type="number" id="cfg-badge-h" value="20" min="16" max="80" oninput="build(); queuePreviewReload()">
               </div>
-              <div class="field">
+              <div class="field" id="badge-gap-field" style="display:none">
                 <label class="field-label">Gap (px)</label>
                 <input type="number" id="cfg-badge-gap" value="8" min="0" max="32" oninput="build(); queuePreviewReload()">
               </div>
@@ -2196,7 +2231,10 @@ function applyLockMode() {
 function updateBadgeModeHint() {
   const mode = parseInt(document.getElementById('cfg-badge-display-mode').value);
   document.getElementById('badge-mode1-hint').style.display        = mode === 1 ? '' : 'none';
-  document.getElementById('badge-quality-fetch-hint').style.display = (mode === 1 || mode === 2) ? '' : 'none';
+  document.getElementById('badge-mode4-hint').style.display        = mode === 4 ? '' : 'none';
+  document.getElementById('badge-quality-fetch-hint').style.display = (mode === 1 || mode === 2 || mode === 4) ? '' : 'none';
+  document.getElementById('badge-gap-field').style.display         = mode === 2 ? '' : 'none';
+  document.getElementById('cfg-badge-h').value                     = mode === 4 ? 20 : 36;
 }
 
 function buildWeightSection(containerId, sources, defaults) {
@@ -2753,6 +2791,7 @@ function buildBaseParams({ usePlaceholders = false } = {}) {
   if (userTmdbKey)    params.set('tmdb_key',     usePlaceholders ? '{tmdb_key}'    : userTmdbKey);
   if (userMdblistKey) params.set('mdblist_key',  usePlaceholders ? '{mdblist_key}' : userMdblistKey);
   params.set('show_award_sash',    c('tog-award-sash') ? 'true' : 'false');
+  params.set('muted',              c('tog-muted')      ? 'true' : 'false');
   params.set('badge_display_mode', ni('cfg-badge-display-mode'));
   params.set('sash_priority',      getSashPriorityParam());
   params.set('rating_display_mode',            ni('cfg-rating-mode'));
@@ -2766,6 +2805,8 @@ function buildBaseParams({ usePlaceholders = false } = {}) {
   params.set('score_glow_threshold',   ni('cfg-glow-thresh'));
   params.set('score_glow_blur',        ni('cfg-glow-blur'));
   params.set('score_glow_alpha',       ni('cfg-glow-alpha'));
+  params.set('textless',                c('tog-textless')         ? 'true' : 'false');
+  params.set('score_color_mode',        ni('cfg-score-color-mode'));
   params.set('logo_max_w_ratio',        n('cfg-logo-w').toFixed(2));
   params.set('logo_max_h_ratio',        n('cfg-logo-h').toFixed(2));
   params.set('logo_bottom_ratio',       n('cfg-logo-bottom').toFixed(2));
@@ -2904,10 +2945,11 @@ async function loadPreview() {
 
 function updateRatingFields() {
   const mode = parseInt(document.getElementById('cfg-rating-mode').value);
-  document.getElementById('rating-mode1-fields').style.display = mode === 1 ? '' : 'none';
-  document.getElementById('rating-mode2-fields').style.display = mode === 2 ? '' : 'none';
-  document.getElementById('rating-mode3-fields').style.display = mode === 3 ? '' : 'none';
-  document.getElementById('rating-glow-fields').style.display  = mode === 1 ? '' : 'none';
+  document.getElementById('rating-mode1-fields').style.display      = mode === 1 ? '' : 'none';
+  document.getElementById('rating-mode2-fields').style.display      = mode === 2 ? '' : 'none';
+  document.getElementById('rating-mode3-fields').style.display      = mode === 3 ? '' : 'none';
+  document.getElementById('rating-glow-fields').style.display       = mode === 1 ? '' : 'none';
+  document.getElementById('rating-alt-colors-toggle').style.display = (mode === 1 || mode === 3) ? '' : 'none';
 }
 
 // ---------------------------------------------------------------------------
@@ -3010,6 +3052,7 @@ function importUrl(urlStr) {
 
   // ── Sash ────────────────────────────────────────────────────────────────
   if (p.has('show_award_sash')) _setEl('tog-award-sash', p.get('show_award_sash'));
+  if (p.has('muted'))           _setEl('tog-muted',      p.get('muted'));
 
   if (p.has('sash_priority')) {
     const tokens = p.get('sash_priority').split(',').map(s => s.trim()).filter(Boolean);
@@ -3038,12 +3081,14 @@ function importUrl(urlStr) {
   if (p.has('score_glow_threshold'))           _setEl('cfg-glow-thresh',  p.get('score_glow_threshold'));
   if (p.has('score_glow_blur'))                _setEl('cfg-glow-blur',    p.get('score_glow_blur'));
   if (p.has('score_glow_alpha'))               _setEl('cfg-glow-alpha',   p.get('score_glow_alpha'));
+  if (p.has('score_color_mode'))               _setEl('cfg-score-color-mode', p.get('score_color_mode'));
   updateRatingFields();
 
   // ── Logo ────────────────────────────────────────────────────────────────
   if (p.has('logo_max_w_ratio'))   _setEl('cfg-logo-w',      p.get('logo_max_w_ratio'));
   if (p.has('logo_max_h_ratio'))   _setEl('cfg-logo-h',      p.get('logo_max_h_ratio'));
   if (p.has('logo_bottom_ratio'))  _setEl('cfg-logo-bottom', p.get('logo_bottom_ratio'));
+  if (p.has('textless'))           _setEl('tog-textless',    p.get('textless'));
 
   // ── Quality badges ──────────────────────────────────────────────────────
   if (p.has('badge_display_mode')) _setEl('cfg-badge-display-mode', p.get('badge_display_mode'));

--- a/digital_release.py
+++ b/digital_release.py
@@ -81,9 +81,8 @@ async def sync_digital_releases(client: httpx.AsyncClient) -> int:
 
         for post in posts:
             posted_at = int(post.get("created_utc", 0))
-            match = _IMDB_RE.search(post.get("selftext", ""))
-            if match:
-                entries.append((match.group(), posted_at))
+            for imdb_id in _IMDB_RE.findall(post.get("selftext", "")):
+                entries.append((imdb_id, posted_at))
 
         if len(posts) < _LIMIT:
             break   # last page — no need to paginate further

--- a/discovery.py
+++ b/discovery.py
@@ -127,7 +127,6 @@ NOTABLE_DIRECTORS: dict[str, str] = {
     "David Cronenberg":    "D. Cronenberg",
     "Michael Mann":        "Michael Mann",
     "Francis Ford Coppola":"F.F Coppola",
-    "Stanley Kubrick":     "S. Kubrick",
     "Jane Campion":        "J. Campion",
     "Terrence Malick":     "T. Malick",
     "Mike Flanagan":       "M. Flanagan",
@@ -252,7 +251,7 @@ LANGUAGE_LABELS: dict[str, str] = {
     "ro": "Romanian",
     "hu": "Hungarian",
     "cs": "Czech",
-    "he": "Israeli",
+    "he": "Hebrew",
     "el": "Greek",
 }
 
@@ -275,7 +274,6 @@ _SASH_TYPES: dict[str, str] = {
     "metacritic":      "nom",       # silver — critical award, fits with noms not production
     "true_story":      "info",      # teal
     "structural":      "info",      # teal
-    "emmy_noms":       "nom",       # silver
 }
 
 NEW_RELEASE_DAYS = 14

--- a/main.py
+++ b/main.py
@@ -11,7 +11,7 @@ import numpy as np
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from fastapi import FastAPI, HTTPException, Request
-from fastapi.responses import Response, HTMLResponse
+from fastapi.responses import JSONResponse, Response, HTMLResponse
 from fastapi.staticfiles import StaticFiles
 from PIL import Image, ImageDraw, ImageFont
 
@@ -76,6 +76,12 @@ class _TruncateUrlFilter(logging.Filter):
 _url_filter = _TruncateUrlFilter()
 for _handler in logging.getLogger().handlers:
     _handler.addFilter(_url_filter)
+
+# httpx logs every outbound HTTP request at INFO level, including full URLs with
+# API keys in query strings.  Raise its level to WARNING so those lines are never
+# written to the log — our own try/except blocks capture errors explicitly.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -165,7 +171,7 @@ async def _background_quality_fetch(
         await coord.release_inflight(coord.NS_QUALITY_BG, imdb_id)
 
 # Local imports
-from age_badge import draw_quality_age_badge
+from age_badge import draw_quality_age_badge, draw_tier_bar
 from awards import FETCH_FAILED, draw_award_sash, parse_mdblist_awards
 from cache import (
     get_cached_quality,
@@ -322,6 +328,9 @@ class RequestConfig:
 
     logo_language: str = field(default_factory=lambda: _cfg.DEFAULT_LOGO_LANGUAGE)
     sash_priority: list[str] = field(default_factory=lambda: list(_cfg.SASH_PRIORITY))
+    muted: bool = False
+    textless: bool = False
+    score_color_mode: int = 0
 
 
 def _parse_bool(val: str | None, default: bool) -> bool:
@@ -378,6 +387,9 @@ def build_request_config(params: dict) -> RequestConfig:
         except: return default
 
     cfg.show_award_sash         = _b("show_award_sash",        cfg.show_award_sash)
+    cfg.muted                   = _b("muted",                  cfg.muted)
+    cfg.textless                = _b("textless",               cfg.textless)
+    cfg.score_color_mode        = _i("score_color_mode",        cfg.score_color_mode)
     cfg.badge_display_mode      = _i("badge_display_mode",     cfg.badge_display_mode)
     cfg.rating_display_mode     = _i("rating_display_mode",    cfg.rating_display_mode)
 
@@ -455,6 +467,20 @@ def _text_center(
 # Poster composition
 # ---------------------------------------------------------------------------
 
+def _make_fallback_canvas() -> Image.Image:
+    """Dark gradient canvas served when a title has no poster art on TMDB."""
+    W, H = _cfg.POSTER_WIDTH, _cfg.POSTER_HEIGHT
+    t    = np.linspace(0, np.pi, H, dtype=np.float32)
+    # sin curve: peaks at midheight (18), dark at top/bottom (10)
+    v    = (10 + 8 * np.sin(t)).astype(np.uint8)
+    arr  = np.zeros((H, W, 4), dtype=np.uint8)
+    arr[:, :, 0] = v[:, np.newaxis]                                          # R
+    arr[:, :, 1] = v[:, np.newaxis]                                          # G
+    arr[:, :, 2] = np.minimum(255, (v * 1.4).astype(np.uint8))[:, np.newaxis]  # B — cool tint
+    arr[:, :, 3] = 255
+    return Image.fromarray(arr, "RGBA")
+
+
 def build_poster(
     image: Image.Image,
     score: int | str,
@@ -466,6 +492,7 @@ def build_poster(
     quality_tokens: list[str] | None = None,
     release_year: str | None = None,
     age_rating: int | None = None,
+    no_poster: bool = False,
 ) -> Image.Image:
 
     width, height = image.size
@@ -523,6 +550,21 @@ def build_poster(
             always_silver=True,
         )
 
+    elif mode == 4:
+        # Accent bar — small vertical pill in tier colour, no text.
+        # Skip when quality_tokens is empty: a grey-tier bar would
+        # misrepresent "unknown quality" as "worst quality" and the
+        # /p endpoint already suppresses persistence in that case, so
+        # avoid leaving a misleading first-render in client/CDN caches.
+        if tokens:
+            draw_tier_bar(
+                image,
+                tokens,
+                anchor_x_ratio=cfg.badge_anchor_x,
+                anchor_y_ratio=cfg.badge_anchor_y,
+                bar_height=cfg.badge_height,
+            )
+
     elif mode == 2:
         allowed_tokens  = {"4K", "1080P", "REMUX", "WEBDL", "DV", "HDR10+", "HDR10"}
         filtered_tokens = [t for t in tokens if t in allowed_tokens]
@@ -577,12 +619,25 @@ def build_poster(
         draw.text((tx + shadow_offset, ty + shadow_offset), fallback_title, font=font, fill=(0, 0, 0, 180))
         draw.text((tx, ty), fallback_title, font=font, fill=(255, 255, 255, 255))
 
+        if no_poster:
+            # Small watermark below the "No Image Available" text so viewers
+            # know this is a PostersPlus message, not a client or CDN failure.
+            try:
+                wm_font = ImageFont.truetype(os.path.join(_FONTS_DIR, "Inter-Bold.ttf"), 13)
+            except IOError:
+                wm_font = ImageFont.load_default()
+            wm_text = "PostersPlus · No poster art on TMDB"
+            wm_bb   = draw.textbbox((0, 0), wm_text, font=wm_font)
+            wm_x    = (width - (wm_bb[2] - wm_bb[0])) // 2
+            wm_y    = ty + (wm_bb[3] - wm_bb[1]) + int(font_size * 1.4)  # type: ignore
+            draw.text((wm_x, wm_y), wm_text, font=wm_font, fill=(160, 160, 160, 110))
+
     # --- Rating / genre label ---
     if cfg.rating_display_mode != 0:
 
         if cfg.rating_display_mode == 1:
             font_size = int(width * cfg.accent_bar_font_size_ratio)
-            label = f"{genre} · {release_year}"
+            label = f"{genre} · {release_year}" if release_year else genre
             rating_cy = height * cfg.accent_bar_y_offset
 
             try:
@@ -602,6 +657,7 @@ def build_poster(
                 glow_threshold=cfg.score_glow_threshold,
                 glow_blur=cfg.score_glow_blur,
                 glow_alpha=cfg.score_glow_alpha,
+                color_mode=cfg.score_color_mode,
             )
 
         elif cfg.rating_display_mode == 2:
@@ -667,6 +723,7 @@ def build_poster(
                     y_center=pip_cy,
                     height=pip_h,
                     width=pip_w,
+                    color_mode=cfg.score_color_mode,
                 )
 
     # --- Discovery sash ---
@@ -674,7 +731,7 @@ def build_poster(
         sash_result = pick_sash(discovery_meta, cfg.sash_priority)
         if sash_result is not None:
             label, sash_type = sash_result
-            image = draw_award_sash(image, label, sash_type=sash_type)
+            image = draw_award_sash(image, label, sash_type=sash_type, muted=cfg.muted)
 
     return image
 
@@ -1146,6 +1203,10 @@ async def get_poster(
     tv_weights: str | None = None,
     logo_language: str | None = None,
     sash_priority: str | None = None,
+    muted: str | None = None,
+    textless: str | None = None,
+    score_color_mode: str | None = None,
+    debug: str | None = None,
 ):
     # Auth gate matches the configurator's preset-only model. When
     # PRESET_ENABLED=true this is a public-tier deployment and /poster
@@ -1215,7 +1276,7 @@ async def get_poster(
         k: v for k, v in request.query_params.items()
         if k not in (
             "tmdb_id", "imdb_id", "mdblist_key", "tmdb_key", "type",
-            "quality", "season", "episode", "access_key",
+            "quality", "season", "episode", "access_key", "debug",
         )
     }
     rcfg = build_request_config(raw_params)
@@ -1225,7 +1286,13 @@ async def get_poster(
     # all rendering parameters so different visual configs don't collide.
     # Skipped when an explicit quality= override is supplied (one-off).
     # ------------------------------------------------------------------
-    if not quality:
+    # debug=1 short-circuits the cache lookup so a cached poster doesn't
+    # mask the diagnostic JSON response further down. The debug branch
+    # never writes to the cache either, so this also prevents debug
+    # responses from polluting future hits.
+    _is_debug = bool(debug and debug.strip() in ("1", "true"))
+
+    if not quality and not _is_debug:
         _params_hash = hashlib.md5(
             "&".join(f"{k}={v}" for k, v in sorted(raw_params.items())).encode()
         ).hexdigest()[:8]
@@ -1235,6 +1302,7 @@ async def get_poster(
         # to authorise a 302 — we never pull the bytes back through the
         # app on a cache hit. With Cloudflare in front of a B2 bucket
         # that's free egress + zero app CPU per hit.
+        etag = f'"{final_cache_key}"'
         cdn_url = get_cached_final_poster_url(final_cache_key)
         if cdn_url is not None:
             if await is_cached_final_poster_fresh(final_cache_key):
@@ -1246,10 +1314,27 @@ async def get_poster(
                 return resp
         else:
             # Local / no-CDN deployment: fall back to inline serving.
+            # Honour upstream's ETag / If-None-Match revalidation so well-
+            # behaved CDN / browser clients can short-circuit with a 304
+            # instead of pulling the bytes again every TTL refresh.
+            #
+            # CRITICAL: check the metadata row is still fresh BEFORE
+            # returning 304 — the ETag is deterministic on
+            # (imdb_id, type, params_hash), so a stale ETag from a client
+            # that's been holding on past COMPOSITE_CACHE_TTL must NOT
+            # be told to reuse expired content. Pull the bytes (which
+            # also confirms metadata + blob freshness) before any 304.
             cached_jpeg = await get_cached_final_poster(final_cache_key)
             if cached_jpeg is not None:
+                if request.headers.get("if-none-match") == etag:
+                    logger.info(f"Final poster ETag match (304) for {final_cache_key}")
+                    return Response(status_code=304)
                 logger.info(f"Final poster cache hit (inline) for {final_cache_key}")
-                return Response(content=cached_jpeg, media_type="image/jpeg")
+                resp = Response(content=cached_jpeg, media_type="image/jpeg")
+                resp.headers["ETag"] = etag
+                if _cfg.CDN_CACHE_TTL > 0:
+                    resp.headers["Cache-Control"] = f"public, max-age={_cfg.CDN_CACHE_TTL}"
+                return resp
     else:
         final_cache_key = None
 
@@ -1265,7 +1350,16 @@ async def get_poster(
         if _existing_fut is not None:
             logger.info(f"Coalescing request for {final_cache_key}")
             try:
-                return Response(content=await _existing_fut, media_type="image/jpeg")
+                _coal_resp = Response(content=await _existing_fut, media_type="image/jpeg")
+                # No ETag + short Cache-Control on coalesced responses:
+                # the future carries only bytes, not the leader's
+                # quality_pending flag, so we can't differentiate
+                # "definitely-cached final render" from "transient
+                # no-badge render". Short TTL keeps downstream caches
+                # honest until the next non-coalesced request settles
+                # which it was.
+                _coal_resp.headers["Cache-Control"] = "public, max-age=300"
+                return _coal_resp
             except Exception:
                 # The in-flight render failed; fall through and try ourselves.
                 pass
@@ -1376,7 +1470,7 @@ async def get_poster(
         quality_tokens = cached_tokens or []
 
     quality_needs_fetch = (
-        rcfg.badge_display_mode in (1, 2)
+        rcfg.badge_display_mode in (1, 2, 4)
         and not quality
         and cached_tokens is None
     )
@@ -1430,14 +1524,15 @@ async def get_poster(
 
         # Quality is always fetched in the background (never inline); the 4th
         # gather slot was removed after quality_needs_fetch was made always-False.
+        is_no_poster = poster_path is None
         (
             image,
             logo,
             rating_result,
             trending_rank,
         ) = await asyncio.gather(
-            fetch_poster_image(client, tmdb_id, type, poster_path),
-            fetch_logo(client, logos, rcfg.logo_language) if is_textless else _resolved(None),
+            _resolved(_make_fallback_canvas()) if is_no_poster else fetch_poster_image(client, tmdb_id, type, poster_path),
+            fetch_logo(client, logos, rcfg.logo_language) if (is_textless and not is_no_poster and not rcfg.textless) else _resolved(None),
             rating_coro,
             fetch_trending_rank(client, tmdb_id, effective_tmdb_key, type),
         )
@@ -1547,21 +1642,58 @@ async def get_poster(
             is_digital_release_override=is_digital_release(imdb_id),
         )
 
+        # ------------------------------------------------------------------
+        # Debug mode: return diagnostic JSON instead of rendering the poster.
+        # Useful for troubleshooting wrong sashes, missing ratings, etc.
+        # Activate with ?debug=1 (never cached, never stored).
+        # ------------------------------------------------------------------
+        if _is_debug:
+            _sash_result = pick_sash(discovery_meta, rcfg.sash_priority)
+            return JSONResponse({
+                "imdb_id":           imdb_id,
+                "tmdb_id":           tmdb_id,
+                "type":              type,
+                "score":             None if score is None else (score if isinstance(score, str) else int(score)),
+                "genre":             genre,
+                "release_year":      release_year,
+                "release_date":      rel,
+                "quality_tokens":    quality_tokens,
+                "age_rating":        age_rating,
+                "award_wins":        award_wins,
+                "award_noms":        award_noms,
+                "festival_label":    festival_label,
+                "sash":              {"label": _sash_result[0], "type": _sash_result[1]} if _sash_result else None,
+                "is_cult":           discovery_meta.is_cult,
+                "is_true_story":     discovery_meta.is_true_story,
+                "is_metacritic":     discovery_meta.is_metacritic_must_see,
+                "is_new_release":    discovery_meta.is_new_release,
+                "is_digital_release":discovery_meta.is_digital_release,
+                "trending_rank":     discovery_meta.trending_rank,
+                "original_language": discovery_meta.original_language,
+                "matched_studios":   discovery_meta.matched_studios,
+                "matched_directors": discovery_meta.matched_directors,
+                "matched_cast":      discovery_meta.matched_cast,
+                "sash_priority":     rcfg.sash_priority,
+                "badge_display_mode":rcfg.badge_display_mode,
+                "rating_display_mode":rcfg.rating_display_mode,
+            })
+
         # Offload CPU-bound PIL compositing + JPEG encoding to the thread pool
         # so the event loop stays free for concurrent requests.
         _bp_args = dict(
-            logo=logo if is_textless else None,
-            fallback_title=title if is_textless and not logo else None,
+            logo=logo if (is_textless and not is_no_poster and not rcfg.textless) else None,
+            fallback_title="No Image Available" if is_no_poster else (title if is_textless and not logo and not rcfg.textless else None),
             discovery_meta=discovery_meta,
             quality_tokens=quality_tokens,
             release_year=release_year,
             age_rating=age_rating,
+            no_poster=is_no_poster,
         )
 
         def _composite_and_encode() -> bytes:
             result = build_poster(image, score, genre, rcfg, **_bp_args)
             buf = io.BytesIO()
-            result.convert("RGB").save(buf, format="JPEG", quality=85)
+            result.convert("RGB").save(buf, format="JPEG", quality=_cfg.JPEG_QUALITY)
             return buf.getvalue()
 
         # Acquire a render slot. If RENDER_QUEUE_TIMEOUT is configured and
@@ -1614,10 +1746,30 @@ async def get_poster(
             _render_fut.set_result(img_bytes)
 
         response = Response(content=img_bytes, media_type="image/jpeg")
-        if _cfg.CDN_CACHE_TTL > 0:
-            response.headers["Cache-Control"] = f"public, max-age={_cfg.CDN_CACHE_TTL}"
+        # Only emit ETag + long Cache-Control when we ALSO persisted
+        # this render. A transient quality-pending response was
+        # deliberately not stored server-side; teaching downstream
+        # caches to hold it for CDN_CACHE_TTL would defeat that and
+        # leave clients stuck with the badge-less version after the
+        # background quality fetch warms the cache. Short revalidate
+        # window keeps the next request live so it picks up warmed data.
+        if final_cache_key is not None and not quality_pending:
+            response.headers["ETag"] = f'"{final_cache_key}"'
+            if _cfg.CDN_CACHE_TTL > 0:
+                response.headers["Cache-Control"] = f"public, max-age={_cfg.CDN_CACHE_TTL}"
+        else:
+            response.headers["Cache-Control"] = "public, max-age=300"
         return response
 
+    except ValueError as exc:
+        # tmdb.fetch_poster_metadata still raises ValueError on hard-fail
+        # metadata fetches (vs. soft no-poster which now lets poster_path
+        # be None and falls through to the fallback canvas). 404 here is
+        # a clear "title not found / no usable metadata" signal.
+        if _render_fut is not None and not _render_fut.done():
+            _render_fut.set_exception(exc)
+        logger.warning(f"No poster available for tmdb_id={tmdb_id}: {exc}")
+        raise HTTPException(status_code=404, detail=str(exc))
     except httpx.TimeoutException as exc:
         if _render_fut is not None and not _render_fut.done():
             _render_fut.set_exception(exc)
@@ -1773,7 +1925,11 @@ async def get_preset_poster(
     # should suppress persistence.
     cached_quality = get_cached_quality(imdb_id, cached_release_date)
     quality_tokens  = cached_quality or []
-    wants_badges    = rcfg.badge_display_mode in (1, 2)
+    # Mode 4 (tier accent bar) is included here because it also reads
+    # quality_tokens — without them the bar renders grey (worst tier).
+    # A first-hit mode-4 render with no cached quality must NOT be
+    # persisted with the long preset TTL or it stays grey for 24h.
+    wants_badges    = rcfg.badge_display_mode in (1, 2, 4)
     quality_missing = wants_badges and cached_quality is None
     will_persist    = cached_rating is not None and not quality_missing
 
@@ -1838,9 +1994,14 @@ async def get_preset_poster(
             await fetch_poster_metadata(client, tmdb_id, effective_tmdb_key, type)
         )
 
+        # Upstream 6a4a2ea no-poster fallback: TMDB metadata exists but no
+        # poster art — serve a dark gradient canvas instead of 500ing. The
+        # preset endpoint inherits the same behaviour so anonymous /p
+        # requests for fringe titles degrade gracefully.
+        is_no_poster = poster_path is None
         image, logo, trending_rank = await asyncio.gather(
-            fetch_poster_image(client, tmdb_id, type, poster_path),
-            fetch_logo(client, logos, rcfg.logo_language) if is_textless else _resolved(None),
+            _resolved(_make_fallback_canvas()) if is_no_poster else fetch_poster_image(client, tmdb_id, type, poster_path),
+            fetch_logo(client, logos, rcfg.logo_language) if (is_textless and not is_no_poster and not rcfg.textless) else _resolved(None),
             fetch_trending_rank(client, tmdb_id, effective_tmdb_key, type),
         )
 
@@ -1860,18 +2021,19 @@ async def get_preset_poster(
         )
 
         _bp_args = dict(
-            logo=logo if is_textless else None,
-            fallback_title=title if is_textless and not logo else None,
+            logo=logo if (is_textless and not is_no_poster and not rcfg.textless) else None,
+            fallback_title="No Image Available" if is_no_poster else (title if is_textless and not logo and not rcfg.textless else None),
             discovery_meta=discovery_meta,
             quality_tokens=quality_tokens,
             release_year=release_year,
             age_rating=age_rating,
+            no_poster=is_no_poster,
         )
 
         def _composite_and_encode() -> bytes:
             result = build_poster(image, score, genre, rcfg, **_bp_args)
             buf = io.BytesIO()
-            result.convert("RGB").save(buf, format="JPEG", quality=85)
+            result.convert("RGB").save(buf, format="JPEG", quality=_cfg.JPEG_QUALITY)
             return buf.getvalue()
 
         global _render_semaphore
@@ -1931,6 +2093,14 @@ async def get_preset_poster(
 
         return Response(content=img_bytes, media_type="image/jpeg", headers=headers)
 
+    except ValueError as exc:
+        # fetch_poster_metadata raises ValueError on hard metadata-fetch
+        # failure (distinct from the soft no-poster path which now lets
+        # poster_path be None and falls through to the fallback canvas).
+        if _render_fut is not None and not _render_fut.done():
+            _render_fut.set_exception(exc)
+        logger.warning(f"Preset: no poster metadata for {imdb_id}: {exc}")
+        raise HTTPException(status_code=404, detail=str(exc))
     except httpx.TimeoutException as exc:
         if _render_fut is not None and not _render_fut.done():
             _render_fut.set_exception(exc)

--- a/presets.py
+++ b/presets.py
@@ -31,10 +31,20 @@ from __future__ import annotations
 
 
 # Common base applied to every preset. Public-tier defaults:
-#   * Badges from cache only (no AIOStreams fan-out per anonymous hit).
-#   * Sash on (the curated discovery overrides are the moat).
+#   * Mode 4 quality indicator (cheap vertical tier-bar pill — much
+#     lighter render cost than mode 1 age-rating numeral or mode 2
+#     full badge row). Cached badges only; never AIOStreams fan-out on
+#     anonymous hits.
+#   * Sash on by default (the curated discovery-override dataset is
+#     the moat — every public hit gets a chance to show a festival or
+#     director sash).
+#
+# Presets pick a small number of axes that meaningfully differ visually
+# while keeping render cost low. The endpoint hashes raw_params into a
+# short params_hash, so fewer distinct presets = fewer composite cache
+# entries per (imdb_id, type) = better cache hit rate at the edge.
 _PUBLIC_BASE: dict[str, str] = {
-    "badge_display_mode": "1",
+    "badge_display_mode": "4",
     "show_award_sash":    "true",
 }
 
@@ -48,47 +58,59 @@ def _preset(extra: dict[str, str]) -> dict[str, str]:
 # preset breaks any external link that already uses it, so rename only
 # with a deprecation alias.
 PRESETS: dict[str, dict[str, str]] = {
-    # Default rendering — same look the configurator emits by default.
-    # The natural choice for embedding posters where you don't have an
-    # opinion about visual tone.
+    # Default rendering. Standard look: weighted score bar + genre/year
+    # caption + a mode-4 tier accent bar in the corner. The natural
+    # choice when no opinion about visual tone is needed.
     "default": _preset({}),
 
-    # Sash-forward. Hides the numeric score so the award/discovery sash
-    # is the dominant element. Useful for catalogues skewed toward
-    # prestige picks (festival winners, AFI lists, "best of" sets).
+    # Sash-forward. The award/discovery sash is the only visible
+    # overlay: score hidden, no quality bar. Muted sash sits *in* the
+    # art rather than above it for a less-shouty prestige look.
     "awards": _preset({
         "rating_display_mode": "0",
+        "badge_display_mode":  "0",
+        "muted":               "true",
     }),
 
-    # Minimalist mode — small genre text bottom-right, no score bar.
-    # Pairs well with grid-heavy UIs that want the poster art to lead.
+    # Minimalist mode — small genre tag bottom-right, no sash, no
+    # quality bar, no logo overlay (textless). Lets the poster art
+    # lead; cheapest preset to render of the set.
     "minimalist": _preset({
         "rating_display_mode": "3",
+        "badge_display_mode":  "0",
+        "show_award_sash":     "false",
+        "textless":            "true",
     }),
 
-    # Letterboxd-flavoured: numeric score with the genre tag, no sash.
-    # Mirrors the audience-score-only aesthetic of letterboxd embeds.
+    # Letterboxd-flavoured: numeric score with genre tag, no sash, no
+    # quality bar. Mirrors the audience-score-only aesthetic of
+    # letterboxd embeds.
     "letterboxd": _preset({
         "rating_display_mode":   "2",
+        "badge_display_mode":    "0",
         "show_award_sash":       "false",
         "movie_weights":         "letterboxd:1.0",
         "tv_weights":            "trakt:0.7,tomatoes:0.3",
     }),
 
-    # Cinephile: prestige-leaning sash priority. Surfaces festival
-    # circuit and director/cast badges before commercial-success ones
-    # like "trending" or "metacritic-must-see".
+    # Cinephile: prestige-leaning sash priority (festival circuit and
+    # director/cast slots before commercial-success ones), muted sash,
+    # and the metal score palette (grey/bronze/silver/gold) matching
+    # the tier-bar colours for a unified subdued look.
     "cinephile": _preset({
         "rating_display_mode": "1",
+        "badge_display_mode":  "4",
         "sash_priority":       "wins,festival,gg_wins,director,cast,studio,pic_noms,gg_noms",
+        "muted":               "true",
+        "score_color_mode":    "2",
     }),
 
-    # Quality-forward: keeps the score visible AND the quality badges
-    # corner-stacked when AIOStreams data is in cache. Good for users
-    # who want stream-availability cues alongside the poster.
+    # Quality-forward: keeps the score visible AND a mode-4 tier bar.
+    # Cheaper than the old badge-row mode and still signals stream
+    # availability when AIOStreams data is cached.
     "quality": _preset({
         "rating_display_mode": "1",
-        "badge_display_mode":  "1",
+        "badge_display_mode":  "4",
     }),
 }
 

--- a/quality.py
+++ b/quality.py
@@ -170,7 +170,7 @@ async def fetch_quality_from_aiostreams(
         logger.warning(f"AIOStreams circuit open — skipping quality fetch for {imdb_id}")
         return FETCH_FAILED
     except Exception as exc:
-        logger.error(f"AIOStreams fetch error for {imdb_id}: {exc}")
+        logger.error(f"AIOStreams fetch error for {imdb_id}: {type(exc).__name__}: {exc}")
         return FETCH_FAILED
 
 

--- a/ratings.py
+++ b/ratings.py
@@ -112,6 +112,34 @@ def _score_color(score: int) -> tuple[tuple[int, int, int], tuple[int, int, int]
         return (190, 140, 255), (186, 85, 211)
 
 
+def _score_color_alt(score: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    """Six-band alternative: dark red → red → dark amber → yellow → dark green → bright green."""
+    if score < 17:    # dark red
+        return (180, 30,  30),  (120, 15,  15)
+    elif score < 34:  # red
+        return (255, 70,  70),  (200, 45,  45)
+    elif score < 50:  # dark amber
+        return (200, 130, 20),  (150, 90,  10)
+    elif score < 67:  # yellow
+        return (255, 215, 60),  (210, 165, 30)
+    elif score < 84:  # dark green
+        return (50,  160, 80),  (25,  110, 50)
+    else:             # bright green
+        return (110, 245, 150), (60,  190, 100)
+
+
+def _score_color_metal(score: int) -> tuple[tuple[int, int, int], tuple[int, int, int]]:
+    """Four-band metal palette mirroring the quality-tier badge colours: grey → bronze → silver → gold."""
+    if score < 50:    # grey
+        return (140, 140, 148), (90,  90,  98)
+    elif score < 70:  # bronze
+        return (210, 120,  50), (150, 80,  25)
+    elif score < 85:  # silver
+        return (218, 224, 240), (155, 165, 195)
+    else:             # gold
+        return (255, 210,  60), (200, 150,  25)
+
+
 def _soften(rgb: tuple[int, int, int], amount: float = 0.9) -> tuple[int, int, int]:
     r, g, b = rgb
     return (
@@ -134,6 +162,7 @@ def draw_score_bar(
     glow_threshold: int = SCORE_GLOW_THRESHOLD,
     glow_blur: int = SCORE_GLOW_BLUR,
     glow_alpha: int = SCORE_GLOW_ALPHA,
+    color_mode: int = 0,
 ) -> None:
     if score is None:
         return
@@ -152,7 +181,8 @@ def draw_score_bar(
     if fill_w <= 0:
         return
     radius = min(bar_h // 2, 8)
-    left_color, right_color = _score_color(score)
+    _color_fn = {1: _score_color_alt, 2: _score_color_metal}.get(color_mode, _score_color)
+    left_color, right_color = _color_fn(score)
     left_color  = _soften(left_color,  0.90)
     right_color = _soften(right_color, 0.90)
 
@@ -228,6 +258,7 @@ def draw_score_bar_vertical(
     y_center: int,
     height: int = 36,
     width: int = 4,
+    color_mode: int = 0,
 ) -> None:
     if score is None:
         return
@@ -238,7 +269,8 @@ def draw_score_bar_vertical(
             return
 
     score = max(0, min(int(score), 100))
-    left_color, right_color = _score_color(score)
+    _color_fn = {1: _score_color_alt, 2: _score_color_metal}.get(color_mode, _score_color)
+    left_color, right_color = _color_fn(score)
     draw = ImageDraw.Draw(image)
     y0 = int(y_center - height / 2)
     y1 = y0 + height

--- a/tmdb.py
+++ b/tmdb.py
@@ -158,7 +158,9 @@ async def fetch_poster_metadata(
         is_textless = False
 
     if not poster_path:
-        raise ValueError("No poster available")
+        logger.warning(f"No poster image on TMDB for tmdb_id={tmdb_id} — fallback canvas will be served")
+        is_textless = False  # no art, no point fetching logos
+        # poster_path stays None; get_poster will generate a fallback canvas
 
     genre_ids            = [g["id"] for g in data.get("genres", [])]
     credits              = data.get("credits", {})


### PR DESCRIPTION
## Summary

Port of upstream [UmbraProjects/PostersPlus@6a4a2ea](https://github.com/UmbraProjects/PostersPlus/commit/6a4a2ea08ea407bf5b265fbab5be845f086c4809) onto the fork — five new visual features:

- **Mode 4 tier accent bar** — single vertical bronze/silver/gold pill, cheaper to render than the existing mode 1 (age-rating numeral) or mode 2 (badge row).
- **Score colour palettes** — default / six-band / metal, applies to score bar and vertical pip.
- **Muted sash** — reduces sash opacity ~85% so it sits in the art rather than above it.
- **Textless toggle** — skips logo overlay for clean art renders.
- **No-poster fallback** — TMDB titles with no art now get a dark cool-gradient canvas with "No Image Available" + PostersPlus watermark instead of a 500.

Plus a JPEG_QUALITY config knob, ETag/304 handling on `/poster`, and a `?debug=1` diagnostic JSON mode.

## ElfHosted-specific extensions

- No-poster fallback ported into the `/p` preset endpoint too (upstream only patched `/poster`).
- Six presets re-tuned to leverage the cheaper mode 4 + cosmetic axes: see [presets.py](presets.py) and the new "Preset re-evaluation" section in [RESILIENCE.md](RESILIENCE.md).

## Codex review

Six iterations to clean. All findings were elfhosted-fork-specific (not in the upstream commit on its own):

1. /p quality guard didn't include mode 4 → would persist grey-tier renders for 24h. Added.
2. 304 returned before validating cache freshness. Now pulls cached bytes first.
3. `?debug=1` could be intercepted by cache hits. Moved debug check above the cache lookup.
4. Mode 4 drew misleading grey bar with empty quality tokens. Now skips entirely.
5. /poster emitted stable ETag + long Cache-Control on transient quality-pending renders. Both suppressed for transient; short TTL.
6. Coalesce path emitted long Cache-Control on potentially-transient renders. Short TTL + no ETag.
7. Debug JSON crashed on `int(None)`. Handles None.
8. textless=true still fetched the logo before discarding. Skipped now.
9. Mode 4 glow composite raised ValueError near 0 badge anchors. Clamps to non-negative dest.

## Out of scope

Skipped from upstream: README/showcase commits, CI/build workflow changes, dockerfile gosu rework (we use containers-private). The README localhost-guidance commit (\`ebcddd4\`) is also skipped — our README is fork-specific.

🤖 Generated with [Claude Code](https://claude.com/claude-code)