### PR TITLE
feat: selective port of upstream v1.0.0 — backdrop fallback, MDBlist semaphore, range clamps, log redaction

### DIFF
--- a/RESILIENCE.md
+++ b/RESILIENCE.md
@@ -785,3 +785,36 @@ Public base default changed: `badge_display_mode` 1→4. Per-preset changes:
 Net: same six preset names (URL contract preserved), same cache cardinality, but the average render is materially cheaper. Anonymous traffic hits the cheaper modes.
 
 Port ready to merge.
+
+### Selective port — upstream v1.0.0 (5b124ca)
+
+Upstream squashed their entire post-`6a4a2ea` development into a single "Release v1.0.0" commit (~1500 lines / 13 files). Lot of it is operational/aesthetic territory that conflicts with this fork (pycairo dependency, gosu, multi-platform Docker, strict requirements.txt pinning, per-section info modals in the configurator). Triaged the new work and applied a focused subset, hand-edited rather than cherry-picked because pycairo + the badge-style sash would have spilled into every file.
+
+**Taken (P0 — security + correctness):**
+
+- **Range-clamped numeric query params** in `build_request_config` — `_f(key, default, lo, hi)` / `_i(key, default, lo, hi)` instead of unbounded `float()`/`int()`. Caps `score_glow_blur` at 50, `badge_height` at 200px, ratios at 0.0–1.5 etc. Stops malicious or careless values from melting a worker (Gaussian kernel at radius 99999, multi-GB image resize).
+- **Expanded log redaction** — the `_TruncateUrlFilter` now redacts `tmdb_key`/`mdblist_key`/`access_key`/`api_key`/`apikey` from `record.msg`, `record.args`, AND pre-formats `record.exc_text` so tracebacks from `logger.exception()` can't leak keys via the formatted upstream URL embedded in an httpx exception.
+- **`draw_score_bar` score=0 empty track** — the track pill is now drawn BEFORE the `fill_w <= 0` early-return so a score of 0 still shows an empty bar rather than disappearing (was visually indistinguishable from "no rating available"). PIL-only port; upstream uses a `_cairo_pill_mask` helper that we skipped along with pycairo.
+
+**Taken (P1 — meaningful new features):**
+
+- **Backdrop fallback** — when TMDB has no textless poster AND no default poster either, the fallback ladder now goes (1) poster, (2) `fetch_backdrop_image` (centre-crops a 16:9 backdrop to 2:3 portrait), (3) `_make_fallback_canvas`. Far better than the previous dark-gradient when art exists. Storage backends got a `backdrop_path` column added to `tmdb_metadata_cache` with idempotent migrations on both SQLite and Postgres. Wired into both `/poster` and `/p` endpoints; when the backdrop is used the watermark + "No Image Available" placeholder are suppressed (it's real art, not a synthetic canvas).
+- **Genre-tinted fallback canvas** — when neither poster nor backdrop exists, the gradient canvas now picks a per-genre RGB tint (deep blood red for horror, indigo for mystery, electric blue for animation, etc.) so the synthetic canvas reads as atmospheric rather than generically dark. Walks `GENRE_PRIORITY` to pick the dominant genre for multi-genre titles.
+- **`MDBLIST_CONCURRENCY` semaphore** — caps concurrent outbound MDBlist HTTP calls (default 3). MDBlist queues or drops requests when hit with too many simultaneous connections from the same key, surfacing as ReadTimeouts under load. The semaphore wraps `fetch_rating` via a thin `_fetch_rating_throttled` helper; bypassed entirely when `MDBLIST_CONCURRENCY=0`.
+
+**Skipped (deliberate fork divergence):**
+
+- **Badge Style sash + Cairo-rasterised badge** — would pull in pycairo (and the libcairo system dep on the image). Cosmetic alternative to the existing diagonal sash; skipping keeps our image lean.
+- **Per-section ⓘ info modals** in the configurator — UX nicety; doesn't move the needle for the public preset-only UI.
+- **`requirements.txt` strict pinning** — conflicts with this fork's hosted-mode deps (psycopg, redis, boto3, prometheus-client, python-json-logger). Different versioning philosophy.
+- **Multi-platform Docker / gosu / dockerfile changes** — we use containers-private with k8s `securityContext`.
+- **MDBlist escalating per-title backoff (30s→2m→8m→1h) + global rate-limit cooldown** — would conflict with our Phase 2 coord-backed backoff (shared across replicas via Redis). The semaphore alone addresses the immediate connection-burst issue; the escalating backoff is a Phase 13 if needed.
+
+**Already in the fork (no-op):**
+
+- `gg_wins`/`gg_noms` split — landed in Phase 5
+- Emmy noms restricted to Outstanding Series only — landed in Phase 5
+- `_safe_cache_path` path-traversal guard — landed in Phase 1
+- Composite cache + rating/render coalescing + lifespan task cancellation + /health + /server-caps + CDN_CACHE_TTL — already done
+
+**Codex review:** first pass clean. Ready to merge.

--- a/config.py
+++ b/config.py
@@ -90,6 +90,13 @@ LOG_FORMAT              = os.environ.get("LOG_FORMAT", "text").strip().lower()
 # supply their own TMDB/MDBList key; otherwise "operator".
 RATE_LIMIT_RPS          = int(os.environ.get("RATE_LIMIT_RPS", "0"))
 
+# Max concurrent outbound MDBlist API calls (ported from upstream v1.0.0).
+# MDBlist queues or drops requests when hit with too many simultaneous
+# connections from the same key, causing ReadTimeouts even when the service
+# is healthy. 3 is comfortably within their apparent per-key concurrency
+# limit while still allowing good parallelism. Set to 0 to disable the cap.
+MDBLIST_CONCURRENCY     = int(os.environ.get("MDBLIST_CONCURRENCY", "3"))
+
 # Workers
 # CDN cache TTL (seconds). When > 0, poster responses include a
 # Cache-Control: public header so Cloudflare (or any CDN) caches them at the

--- a/main.py
+++ b/main.py
@@ -49,10 +49,33 @@ for _uv_name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
 
 
 class _TruncateUrlFilter(logging.Filter):
-    """Redact API keys and truncate long URL paths in uvicorn access log records."""
+    """
+    Redact API keys and truncate long URL paths in log records.
+
+    Two responsibilities:
+      1. For uvicorn.access records, truncate the request path so long URLs
+         don't fill the log.
+      2. For ALL records, redact every common API-key query parameter pattern
+         in record.msg AND record.args AND any pre-formatted exc_text. This
+         catches keys that slip through when an httpx exception is logged
+         (its __str__ includes the full upstream URL with our outbound
+         api_key=) or when application code formats a key into an error
+         message before logging.
+    """
     _MAX = 80
-    # Redact any query param whose name ends in _key or is access_key
-    _KEY_RE = re.compile(r'((?:tmdb_key|mdblist_key|access_key)=)[^&\s]*', re.IGNORECASE)
+    # Match both the params our callers pass us (tmdb_key, mdblist_key,
+    # access_key) AND the upstream parameter names we forward keys under
+    # (api_key, apikey — used by TMDB and MDBlist respectively).
+    _KEY_RE = re.compile(
+        r'((?:tmdb_key|mdblist_key|access_key|api_key|apikey)=)[^&\s\'\"]*',
+        re.IGNORECASE,
+    )
+
+    @classmethod
+    def _redact(cls, value):
+        if isinstance(value, str):
+            return cls._KEY_RE.sub(r'\1***', value)
+        return value
 
     def filter(self, record: logging.LogRecord) -> bool:
         # uvicorn.access records: args = (client_addr, method, path, http_version, status_code, ...)
@@ -63,11 +86,31 @@ class _TruncateUrlFilter(logging.Filter):
         ):
             path = record.args[2]
             if isinstance(path, str):
-                # Redact before truncating so keys are never logged regardless of length
                 path = self._KEY_RE.sub(r'\1***', path)
                 if len(path) > self._MAX:
                     path = path[: self._MAX] + "…"
                 record.args = (record.args[0], record.args[1], path) + record.args[3:]
+
+        # Generic redaction on every record. msg + args cover f-strings,
+        # %-formatting, and pre-built messages.
+        if isinstance(record.msg, str):
+            record.msg = self._redact(record.msg)
+        if isinstance(record.args, tuple):
+            record.args = tuple(self._redact(a) for a in record.args)
+        elif isinstance(record.args, dict):
+            record.args = {k: self._redact(v) for k, v in record.args.items()}
+
+        # Tracebacks (logger.exception / exc_info=True) are formatted lazily
+        # by the handler. Pre-format and redact exc_text here so the
+        # downstream formatter uses our sanitised copy rather than re-rendering.
+        if record.exc_info and not record.exc_text:
+            import traceback
+            record.exc_text = self._redact(
+                "".join(traceback.format_exception(*record.exc_info))
+            )
+        elif record.exc_text:
+            record.exc_text = self._redact(record.exc_text)
+
         return True
 
 
@@ -122,6 +165,12 @@ _render_semaphore: "asyncio.Semaphore | None" = None
 #   doesn't hammer the scrapers with hundreds of simultaneous requests.
 
 _quality_bg_semaphore: "asyncio.Semaphore | None" = None   # created inside event loop
+
+# Caps concurrent outbound MDBlist HTTP calls so a poster-burst can't trip
+# MDBlist's per-key connection cap (manifests as ReadTimeout even when the
+# service is healthy). Created lazily in the event loop on first use.
+# Sized via config.MDBLIST_CONCURRENCY (0 disables the gate).
+_mdblist_semaphore: "asyncio.Semaphore | None" = None
 
 # ---------------------------------------------------------------------------
 # Rating fetch deduplication
@@ -212,6 +261,7 @@ from tmdb import (
     fetch_logo,
     fetch_poster_metadata,
     fetch_poster_image,
+    fetch_backdrop_image,
     fetch_trending_rank,
     resolve_imdb_to_tmdb,
 )
@@ -375,23 +425,39 @@ def _parse_sash_priority(raw: str | None) -> list[str]:
 
 
 def build_request_config(params: dict) -> RequestConfig:
-    """Build a RequestConfig from raw query-param strings."""
+    """Build a RequestConfig from raw query-param strings.
+
+    All numeric overrides are clamped to a sensible range so a malicious or
+    careless caller can't pass values that would melt a worker (e.g.
+    score_glow_blur=99999 turning into a Gaussian kernel of that radius, or
+    badge_height=99999 triggering a multi-GB image resize). Bounds are
+    deliberately a little more generous than the configurator sliders so
+    power users can push past UI limits without bypassing safety.
+    """
     cfg = RequestConfig()
 
     def _b(key, default): return _parse_bool(params.get(key), default)
-    def _f(key, default):
-        try:    return float(params[key]) if key in params else default
-        except: return default
-    def _i(key, default):
-        try:    return int(params[key]) if key in params else default
-        except: return default
+
+    def _f(key, default, lo: float, hi: float):
+        """Float param with hard clamp to [lo, hi]; invalid → default."""
+        try:
+            return max(lo, min(hi, float(params[key]))) if key in params else default
+        except (ValueError, TypeError):
+            return default
+
+    def _i(key, default, lo: int, hi: int):
+        """Int param with hard clamp to [lo, hi]; invalid → default."""
+        try:
+            return max(lo, min(hi, int(params[key]))) if key in params else default
+        except (ValueError, TypeError):
+            return default
 
     cfg.show_award_sash         = _b("show_award_sash",        cfg.show_award_sash)
     cfg.muted                   = _b("muted",                  cfg.muted)
     cfg.textless                = _b("textless",               cfg.textless)
-    cfg.score_color_mode        = _i("score_color_mode",        cfg.score_color_mode)
-    cfg.badge_display_mode      = _i("badge_display_mode",     cfg.badge_display_mode)
-    cfg.rating_display_mode     = _i("rating_display_mode",    cfg.rating_display_mode)
+    cfg.score_color_mode        = _i("score_color_mode",       cfg.score_color_mode,       0,   2)
+    cfg.badge_display_mode      = _i("badge_display_mode",     cfg.badge_display_mode,     0,   4)
+    cfg.rating_display_mode     = _i("rating_display_mode",    cfg.rating_display_mode,    0,   3)
 
     if "show_quality_badges" in params and "badge_display_mode" not in params:
         if _parse_bool(params.get("show_quality_badges"), True):
@@ -399,25 +465,31 @@ def build_request_config(params: dict) -> RequestConfig:
         else:
             cfg.badge_display_mode = 0
 
-    cfg.accent_bar_font_size_ratio    = _f("accent_bar_font_size_ratio",    cfg.accent_bar_font_size_ratio)
-    cfg.numeric_score_font_size_ratio = _f("numeric_score_font_size_ratio", cfg.numeric_score_font_size_ratio)
-    cfg.accent_bar_y_offset           = _f("accent_bar_y_offset",           cfg.accent_bar_y_offset)
-    cfg.numeric_score_y_offset        = _f("numeric_score_y_offset",        cfg.numeric_score_y_offset)
-    cfg.score_glow_threshold          = _i("score_glow_threshold",          cfg.score_glow_threshold)
-    cfg.score_glow_blur               = _i("score_glow_blur",               cfg.score_glow_blur)
-    cfg.score_glow_alpha              = _i("score_glow_alpha",              cfg.score_glow_alpha)
-    cfg.minimalist_mode_font_size_ratio = _f("minimalist_mode_font_size_ratio", cfg.minimalist_mode_font_size_ratio)
-    cfg.minimalist_mode_font_x_offset = _f("minimalist_mode_font_x_offset", cfg.minimalist_mode_font_x_offset)
-    cfg.minimalist_mode_font_y_offset = _f("minimalist_mode_font_y_offset", cfg.minimalist_mode_font_y_offset)
+    # Font-size ratios are multiplied by the poster width — anything above
+    # ~0.3 would overflow the poster; cap at 0.5 to leave headroom.
+    cfg.accent_bar_font_size_ratio    = _f("accent_bar_font_size_ratio",    cfg.accent_bar_font_size_ratio,    0.0, 0.5)
+    cfg.numeric_score_font_size_ratio = _f("numeric_score_font_size_ratio", cfg.numeric_score_font_size_ratio, 0.0, 0.5)
+    cfg.accent_bar_y_offset           = _f("accent_bar_y_offset",           cfg.accent_bar_y_offset,           0.0, 1.0)
+    cfg.numeric_score_y_offset        = _f("numeric_score_y_offset",        cfg.numeric_score_y_offset,        0.0, 1.0)
+    cfg.score_glow_threshold          = _i("score_glow_threshold",          cfg.score_glow_threshold,          0,   100)
+    # Glow blur is a Gaussian kernel radius — cost is O(r²) per pixel, so
+    # anything above ~50 starts measurably slowing the render. Hard cap at 50.
+    cfg.score_glow_blur               = _i("score_glow_blur",               cfg.score_glow_blur,               0,   50)
+    cfg.score_glow_alpha              = _i("score_glow_alpha",              cfg.score_glow_alpha,              0,   255)
+    cfg.minimalist_mode_font_size_ratio = _f("minimalist_mode_font_size_ratio", cfg.minimalist_mode_font_size_ratio, 0.0, 0.5)
+    cfg.minimalist_mode_font_x_offset = _f("minimalist_mode_font_x_offset", cfg.minimalist_mode_font_x_offset, 0.0, 1.0)
+    cfg.minimalist_mode_font_y_offset = _f("minimalist_mode_font_y_offset", cfg.minimalist_mode_font_y_offset, 0.0, 1.0)
 
-    cfg.logo_max_w_ratio  = _f("logo_max_w_ratio",  cfg.logo_max_w_ratio)
-    cfg.logo_max_h_ratio  = _f("logo_max_h_ratio",  cfg.logo_max_h_ratio)
-    cfg.logo_bottom_ratio = _f("logo_bottom_ratio", cfg.logo_bottom_ratio)
+    cfg.logo_max_w_ratio  = _f("logo_max_w_ratio",  cfg.logo_max_w_ratio,  0.0, 1.5)
+    cfg.logo_max_h_ratio  = _f("logo_max_h_ratio",  cfg.logo_max_h_ratio,  0.0, 1.0)
+    cfg.logo_bottom_ratio = _f("logo_bottom_ratio", cfg.logo_bottom_ratio, 0.0, 1.0)
 
-    cfg.badge_height   = _i("badge_height",   cfg.badge_height)
-    cfg.badge_gap      = _i("badge_gap",       cfg.badge_gap)
-    cfg.badge_anchor_x = _f("badge_anchor_x", cfg.badge_anchor_x)
-    cfg.badge_anchor_y = _f("badge_anchor_y", cfg.badge_anchor_y)
+    # badge_height in pixels — generous enough for customisation but well
+    # below the size that would cost real memory on resize.
+    cfg.badge_height   = _i("badge_height",   cfg.badge_height,   1,   200)
+    cfg.badge_gap      = _i("badge_gap",      cfg.badge_gap,      0,   100)
+    cfg.badge_anchor_x = _f("badge_anchor_x", cfg.badge_anchor_x, 0.0, 1.0)
+    cfg.badge_anchor_y = _f("badge_anchor_y", cfg.badge_anchor_y, 0.0, 1.0)
 
     all_sources = list(_cfg.MOVIE_WEIGHTS.keys())
     cfg.movie_weights = _parse_weights(params.get("movie_weights"), all_sources)
@@ -447,6 +519,21 @@ async def _with_retry(coro_fn, *args, **kwargs):
     return result
 
 
+async def _fetch_rating_throttled(*args, **kwargs):
+    """Wrap fetch_rating in the MDBLIST_CONCURRENCY semaphore so a burst of
+    uncached posters can't trip MDBlist's per-key connection limit
+    (manifests as ReadTimeout under load). When MDBLIST_CONCURRENCY=0 the
+    semaphore is bypassed entirely — preserves upstream behaviour for
+    self-hosters who don't want the gate."""
+    global _mdblist_semaphore
+    if _cfg.MDBLIST_CONCURRENCY <= 0:
+        return await fetch_rating(*args, **kwargs)
+    if _mdblist_semaphore is None:
+        _mdblist_semaphore = asyncio.Semaphore(_cfg.MDBLIST_CONCURRENCY)
+    async with _mdblist_semaphore:
+        return await fetch_rating(*args, **kwargs)
+
+
 def _text_center(
     draw: ImageDraw.ImageDraw,
     text: str,
@@ -467,16 +554,72 @@ def _text_center(
 # Poster composition
 # ---------------------------------------------------------------------------
 
-def _make_fallback_canvas() -> Image.Image:
-    """Dark gradient canvas served when a title has no poster art on TMDB."""
+# Genre-specific tint multipliers (R, G, B) for the fallback canvas.
+# Applied to a dark base luminance of 10–18 so the dominant channel peaks
+# around 30–55 at canvas midpoint — atmospheric rather than vivid. Names
+# must match GENRE_MAP values exactly.
+_GENRE_TINT: dict[str, tuple[float, float, float]] = {
+    "Horror":      (3.2, 0.3, 0.3),   # deep blood red
+    "Thriller":    (0.4, 2.2, 0.5),   # dark hunter green
+    "Mystery":     (1.0, 0.3, 3.0),   # deep indigo
+    "Sci-Fi":      (0.3, 1.2, 3.2),   # cold cyan-blue
+    "Fantasy":     (1.6, 0.3, 3.0),   # purple-violet
+    "Action":      (3.0, 0.8, 0.3),   # orange-red
+    "Adventure":   (2.6, 1.5, 0.3),   # warm amber
+    "Animation":   (0.4, 0.8, 3.2),   # electric blue
+    "Comedy":      (2.6, 2.4, 0.3),   # golden yellow
+    "Crime":       (2.4, 0.2, 0.2),   # dark crimson
+    "Documentary": (0.3, 2.2, 2.4),   # teal
+    "Drama":       (0.3, 0.3, 2.6),   # deep blue
+    "Family":      (2.6, 1.2, 0.3),   # warm orange
+    "History":     (2.2, 1.1, 0.3),   # sepia
+    "Music":       (2.8, 0.3, 2.2),   # magenta
+    "Romance":     (3.0, 0.3, 0.9),   # rose
+    "War":         (0.9, 1.6, 0.3),   # olive green
+    "Western":     (2.8, 1.1, 0.2),   # burnt sienna
+    "Kids":        (0.3, 1.1, 3.0),   # bright blue
+    "Reality":     (2.4, 0.8, 0.3),   # orange
+    "Soap":        (2.6, 0.3, 0.9),   # rose-pink
+    "Talk":        (0.3, 1.6, 2.4),   # teal-blue
+    "News":        (0.3, 0.5, 2.6),   # steel blue
+}
+_FALLBACK_DEFAULT_TINT = (1.0, 1.0, 1.4)   # neutral cool blue
+
+
+def _make_fallback_canvas(genre_ids: list[int] | None = None) -> Image.Image:
+    """
+    Dark gradient canvas served when a title has no poster art and no
+    suitable backdrop on TMDB.
+
+    Applies a genre-derived colour tint so the canvas feels atmospheric
+    rather than generically dark. The base luminance is 10–18 (very dark)
+    so even the dominant channel stays below ~55 — readable against the
+    white "No Image Available" overlay added by build_poster.
+    """
+    # Resolve genre → tint by walking GENRE_PRIORITY so higher-priority
+    # genres win when a title belongs to multiple genres (same order as
+    # the score label).
+    tint = _FALLBACK_DEFAULT_TINT
+    if genre_ids:
+        gid_set = set(genre_ids)
+        for gid in _cfg.GENRE_PRIORITY:
+            if gid in gid_set:
+                name = _cfg.GENRE_MAP.get(gid)
+                if name and name in _GENRE_TINT:
+                    tint = _GENRE_TINT[name]
+                    break
+
+    r_mult, g_mult, b_mult = tint
     W, H = _cfg.POSTER_WIDTH, _cfg.POSTER_HEIGHT
     t    = np.linspace(0, np.pi, H, dtype=np.float32)
-    # sin curve: peaks at midheight (18), dark at top/bottom (10)
-    v    = (10 + 8 * np.sin(t)).astype(np.uint8)
+    # sin curve: peaks at midheight (~18), dark at top/bottom (~10)
+    v    = (10 + 8 * np.sin(t)).astype(np.float32)
     arr  = np.zeros((H, W, 4), dtype=np.uint8)
-    arr[:, :, 0] = v[:, np.newaxis]                                          # R
-    arr[:, :, 1] = v[:, np.newaxis]                                          # G
-    arr[:, :, 2] = np.minimum(255, (v * 1.4).astype(np.uint8))[:, np.newaxis]  # B — cool tint
+    # Clamp BEFORE casting to uint8 — casting first would wrap mod-256 on
+    # any value above 255, silently inverting colour for high-multiplier tints.
+    arr[:, :, 0] = np.minimum(255, v * r_mult).astype(np.uint8)[:, np.newaxis]
+    arr[:, :, 1] = np.minimum(255, v * g_mult).astype(np.uint8)[:, np.newaxis]
+    arr[:, :, 2] = np.minimum(255, v * b_mult).astype(np.uint8)[:, np.newaxis]
     arr[:, :, 3] = 255
     return Image.fromarray(arr, "RGBA")
 
@@ -1506,7 +1649,7 @@ async def get_poster(
     client = _HTTP_CLIENT
 
     try:
-        genre_ids, is_textless, logos, release_year, title, poster_path, tmdb_data = (
+        genre_ids, is_textless, logos, release_year, title, poster_path, backdrop_path, tmdb_data = (
             await fetch_poster_metadata(client, tmdb_id, effective_tmdb_key, type)
         )
 
@@ -1516,22 +1659,35 @@ async def get_poster(
             )
         else:
             rating_coro = _with_retry(
-                fetch_rating,
+                _fetch_rating_throttled,
                 client, imdb_id, effective_mdblist_key, genre_ids, type,
                 movie_weights=effective_movie_weights,
                 tv_weights=effective_tv_weights,
             )
 
-        # Quality is always fetched in the background (never inline); the 4th
-        # gather slot was removed after quality_needs_fetch was made always-False.
+        # No-poster fallback ladder:
+        #   1. poster_path present → fetch the textless/default poster
+        #   2. else backdrop_path present → fetch landscape backdrop +
+        #      centre-crop to portrait
+        #   3. else _make_fallback_canvas() (dark gradient)
         is_no_poster = poster_path is None
+        use_backdrop = is_no_poster and backdrop_path is not None
+        if use_backdrop:
+            image_coro = fetch_backdrop_image(client, tmdb_id, backdrop_path)
+        elif is_no_poster:
+            image_coro = _resolved(_make_fallback_canvas(genre_ids))
+        else:
+            image_coro = fetch_poster_image(client, tmdb_id, type, poster_path)
+
+        # No logo when there's no real poster art — both the canvas and
+        # the backdrop already read as standalone images.
         (
             image,
             logo,
             rating_result,
             trending_rank,
         ) = await asyncio.gather(
-            _resolved(_make_fallback_canvas()) if is_no_poster else fetch_poster_image(client, tmdb_id, type, poster_path),
+            image_coro,
             fetch_logo(client, logos, rcfg.logo_language) if (is_textless and not is_no_poster and not rcfg.textless) else _resolved(None),
             rating_coro,
             fetch_trending_rank(client, tmdb_id, effective_tmdb_key, type),
@@ -1680,14 +1836,27 @@ async def get_poster(
 
         # Offload CPU-bound PIL compositing + JPEG encoding to the thread pool
         # so the event loop stays free for concurrent requests.
+        #
+        # Three image-source cases:
+        #   * Real poster — render normally with title logo overlay if textless.
+        #   * Backdrop fallback — real art, just landscape-cropped. No
+        #     "No Image Available" overlay and no watermark; the user is
+        #     getting a genuine TMDB asset.
+        #   * Canvas fallback — synthetic gradient, gets the watermark +
+        #     "No Image Available" so viewers know it's a PostersPlus
+        #     placeholder, not a CDN failure.
         _bp_args = dict(
             logo=logo if (is_textless and not is_no_poster and not rcfg.textless) else None,
-            fallback_title="No Image Available" if is_no_poster else (title if is_textless and not logo and not rcfg.textless else None),
+            fallback_title=(
+                None if use_backdrop
+                else "No Image Available" if is_no_poster
+                else (title if is_textless and not logo and not rcfg.textless else None)
+            ),
             discovery_meta=discovery_meta,
             quality_tokens=quality_tokens,
             release_year=release_year,
             age_rating=age_rating,
-            no_poster=is_no_poster,
+            no_poster=is_no_poster and not use_backdrop,
         )
 
         def _composite_and_encode() -> bytes:
@@ -1990,17 +2159,25 @@ async def get_preset_poster(
         is_metacritic  = False
 
     try:
-        genre_ids, is_textless, logos, release_year, title, poster_path, tmdb_data = (
+        genre_ids, is_textless, logos, release_year, title, poster_path, backdrop_path, tmdb_data = (
             await fetch_poster_metadata(client, tmdb_id, effective_tmdb_key, type)
         )
 
-        # Upstream 6a4a2ea no-poster fallback: TMDB metadata exists but no
-        # poster art — serve a dark gradient canvas instead of 500ing. The
-        # preset endpoint inherits the same behaviour so anonymous /p
-        # requests for fringe titles degrade gracefully.
+        # No-poster fallback ladder (same as /poster):
+        #   1. poster_path  → textless or default poster
+        #   2. backdrop_path → landscape backdrop centre-cropped to portrait
+        #   3. neither       → dark gradient canvas
         is_no_poster = poster_path is None
+        use_backdrop = is_no_poster and backdrop_path is not None
+        if use_backdrop:
+            image_coro = fetch_backdrop_image(client, tmdb_id, backdrop_path)
+        elif is_no_poster:
+            image_coro = _resolved(_make_fallback_canvas(genre_ids))
+        else:
+            image_coro = fetch_poster_image(client, tmdb_id, type, poster_path)
+
         image, logo, trending_rank = await asyncio.gather(
-            _resolved(_make_fallback_canvas()) if is_no_poster else fetch_poster_image(client, tmdb_id, type, poster_path),
+            image_coro,
             fetch_logo(client, logos, rcfg.logo_language) if (is_textless and not is_no_poster and not rcfg.textless) else _resolved(None),
             fetch_trending_rank(client, tmdb_id, effective_tmdb_key, type),
         )
@@ -2020,14 +2197,19 @@ async def get_preset_poster(
             is_digital_release_override=is_digital_release(imdb_id),
         )
 
+        # Backdrop fallback case: real art, suppress watermark + placeholder.
         _bp_args = dict(
             logo=logo if (is_textless and not is_no_poster and not rcfg.textless) else None,
-            fallback_title="No Image Available" if is_no_poster else (title if is_textless and not logo and not rcfg.textless else None),
+            fallback_title=(
+                None if use_backdrop
+                else "No Image Available" if is_no_poster
+                else (title if is_textless and not logo and not rcfg.textless else None)
+            ),
             discovery_meta=discovery_meta,
             quality_tokens=quality_tokens,
             release_year=release_year,
             age_rating=age_rating,
-            no_poster=is_no_poster,
+            no_poster=is_no_poster and not use_backdrop,
         )
 
         def _composite_and_encode() -> bytes:

--- a/ratings.py
+++ b/ratings.py
@@ -178,15 +178,12 @@ def draw_score_bar(
     y1, y0  = H - bottom_margin, H - bottom_margin - bar_h
     bar_w   = x1 - x0
     fill_w  = int(bar_w * (score / 100))
-    if fill_w <= 0:
-        return
     radius = min(bar_h // 2, 8)
-    _color_fn = {1: _score_color_alt, 2: _score_color_metal}.get(color_mode, _score_color)
-    left_color, right_color = _color_fn(score)
-    left_color  = _soften(left_color,  0.90)
-    right_color = _soften(right_color, 0.90)
 
     # ── Track (background pill) ───────────────────────────────────────────
+    # Drawn BEFORE the fill_w<=0 early-return so score=0 still shows an
+    # empty track rather than no bar at all (which would otherwise be
+    # visually indistinguishable from "no rating available").
     track = Image.new("RGBA", (W, H), (0, 0, 0, 0))
     ImageDraw.Draw(track).rounded_rectangle(
         [(x0, y0), (x1 - 1, y1 - 1)],
@@ -194,6 +191,13 @@ def draw_score_bar(
         fill=(255, 255, 255, 45),
     )
     image.alpha_composite(track)
+
+    if fill_w <= 0:
+        return
+    _color_fn = {1: _score_color_alt, 2: _score_color_metal}.get(color_mode, _score_color)
+    left_color, right_color = _color_fn(score)
+    left_color  = _soften(left_color,  0.90)
+    right_color = _soften(right_color, 0.90)
 
     # ── Filled segment — numpy gradient, no Python pixel loop ────────────
     # Build an (bar_h × fill_w) RGB array by interpolating left→right colour.

--- a/storage/postgres_backend.py
+++ b/storage/postgres_backend.py
@@ -123,8 +123,14 @@ def _bootstrap_schema(conn) -> None:
                 runtime             INTEGER,
                 number_of_seasons   INTEGER,
                 number_of_episodes  INTEGER,
-                original_language   TEXT
+                original_language   TEXT,
+                backdrop_path       TEXT
             )
+        """)
+        # Idempotent backdrop_path migration for instances that pre-date the
+        # backdrop fallback feature. Safe to run on every startup.
+        cur.execute("""
+            ALTER TABLE tmdb_metadata_cache ADD COLUMN IF NOT EXISTS backdrop_path TEXT
         """)
         # Phase 10: composite-poster bytes live in blobstore (FS or S3); the
         # table holds only metadata so the relational backend can do TTL
@@ -596,7 +602,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
                            logos_json, cached_at,
                            credits_json, production_cos_json,
                            runtime, number_of_seasons, number_of_episodes,
-                           original_language
+                           original_language, backdrop_path
                     FROM tmdb_metadata_cache
                     WHERE cache_key = %s
                     """,
@@ -611,7 +617,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
                     logos_json, cached_at,
                     credits_json, production_cos_json,
                     runtime, number_of_seasons, number_of_episodes,
-                    original_language,
+                    original_language, backdrop_path,
                 ) = row
 
                 age_days = (time.time() - cached_at) / 86400
@@ -637,6 +643,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
                     "number_of_seasons":    number_of_seasons,
                     "number_of_episodes":   number_of_episodes,
                     "original_language":    original_language,
+                    "backdrop_path":        backdrop_path,
                 }
     except Exception as exc:
         logger.error(f"TMDB metadata cache read error: {exc}")
@@ -658,6 +665,7 @@ def set_cached_tmdb_metadata(
     runtime: int | None = None,
     number_of_seasons: int | None = None,
     number_of_episodes: int | None = None,
+    backdrop_path: str | None = None,
 ) -> None:
     try:
         with _get_pool().connection() as conn:
@@ -669,8 +677,8 @@ def set_cached_tmdb_metadata(
                          poster_path, logos_json, cached_at,
                          credits_json, production_cos_json,
                          runtime, number_of_seasons, number_of_episodes,
-                         original_language)
-                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                         original_language, backdrop_path)
+                    VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
                     ON CONFLICT (cache_key) DO UPDATE SET
                         title               = EXCLUDED.title,
                         release_year        = EXCLUDED.release_year,
@@ -684,7 +692,8 @@ def set_cached_tmdb_metadata(
                         runtime             = EXCLUDED.runtime,
                         number_of_seasons   = EXCLUDED.number_of_seasons,
                         number_of_episodes  = EXCLUDED.number_of_episodes,
-                        original_language   = EXCLUDED.original_language
+                        original_language   = EXCLUDED.original_language,
+                        backdrop_path       = EXCLUDED.backdrop_path
                     """,
                     (
                         cache_key,
@@ -701,6 +710,7 @@ def set_cached_tmdb_metadata(
                         number_of_seasons,
                         number_of_episodes,
                         original_language,
+                        backdrop_path,
                     ),
                 )
             conn.commit()

--- a/storage/sqlite_backend.py
+++ b/storage/sqlite_backend.py
@@ -131,7 +131,8 @@ def init_db() -> None:
             runtime             INTEGER,
             number_of_seasons   INTEGER,
             number_of_episodes  INTEGER,
-            original_language   TEXT
+            original_language   TEXT,
+            backdrop_path       TEXT
         )
     """)
 
@@ -208,6 +209,7 @@ def init_db() -> None:
         ("number_of_seasons",   "INTEGER"),
         ("number_of_episodes",  "INTEGER"),
         ("original_language",   "TEXT"),
+        ("backdrop_path",       "TEXT"),
     ):
         if col not in existing_meta_cols:
             _db_conn.execute(
@@ -736,7 +738,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
                    logos_json, cached_at,
                    credits_json, production_cos_json,
                    runtime, number_of_seasons, number_of_episodes,
-                   original_language
+                   original_language, backdrop_path
             FROM tmdb_metadata_cache
             WHERE cache_key = ?
             """,
@@ -750,7 +752,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
             logos_json, cached_at,
             credits_json, production_cos_json,
             runtime, number_of_seasons, number_of_episodes,
-            original_language,
+            original_language, backdrop_path,
         ) = row
 
         age_days = (time.time() - cached_at) / 86400
@@ -776,6 +778,7 @@ def get_cached_tmdb_metadata(cache_key: str) -> dict | None:
             "number_of_seasons":    number_of_seasons,
             "number_of_episodes":   number_of_episodes,
             "original_language":    original_language,
+            "backdrop_path":        backdrop_path,
         }
     except Exception as exc:
         logger.error(f"TMDB metadata cache read error: {exc}")
@@ -797,6 +800,7 @@ def set_cached_tmdb_metadata(
     runtime: int | None = None,
     number_of_seasons: int | None = None,
     number_of_episodes: int | None = None,
+    backdrop_path: str | None = None,
 ) -> None:
     try:
         with _db_lock:
@@ -807,8 +811,8 @@ def set_cached_tmdb_metadata(
                      poster_path, logos_json, cached_at,
                      credits_json, production_cos_json,
                      runtime, number_of_seasons, number_of_episodes,
-                     original_language)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                     original_language, backdrop_path)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     cache_key,
@@ -825,6 +829,7 @@ def set_cached_tmdb_metadata(
                     number_of_seasons,
                     number_of_episodes,
                     original_language,
+                    backdrop_path,
                 ),
             )
             get_db().commit()

--- a/tmdb.py
+++ b/tmdb.py
@@ -86,13 +86,18 @@ async def fetch_poster_metadata(
     tmdb_id: str,
     tmdb_key: str,
     media_type: str = "movie",
-) -> tuple[list[int], bool, list[dict], str | None, str, str, dict]:
+) -> tuple[list[int], bool, list[dict], str | None, str, str, str | None, dict]:
     """
     Fetch (or return cached) TMDB metadata, including credits,
     production_companies, and original_language for discovery sash logic.
 
     Returns:
-        (genre_ids, is_textless, logos, release_year, title, poster_path, tmdb_data)
+        (genre_ids, is_textless, logos, release_year, title, poster_path,
+         backdrop_path, tmdb_data)
+
+    backdrop_path is a textless landscape backdrop ready to be centre-cropped
+    to portrait when no textless poster exists (handled by main.py). None when
+    TMDB has no language-neutral backdrop for the title.
     """
     endpoint = "tv" if media_type in ("tv", "series") else "movie"
     metadata_cache_key = f"{endpoint}_{tmdb_id}"
@@ -116,6 +121,7 @@ async def fetch_poster_metadata(
             meta["release_year"],
             meta["title"],
             meta["poster_path"],
+            meta.get("backdrop_path"),
             tmdb_data,
         )
 
@@ -128,6 +134,9 @@ async def fetch_poster_metadata(
         params={
             "api_key": tmdb_key,
             "append_to_response": "images,credits",
+            # null = TMDB's signal for language-neutral entries (textless),
+            # which is what we want for both posters and backdrops.
+            "include_image_language": "en,null",
         },
     )
     data = resp.json()
@@ -143,11 +152,14 @@ async def fetch_poster_metadata(
     raw_date = data.get("release_date") or data.get("first_air_date") or ""
     release_year: str | None = raw_date[:4] if len(raw_date) >= 4 else None
 
-    images  = data.get("images", {})
-    posters = images.get("posters", [])
-    logos   = images.get("logos", [])
+    images    = data.get("images", {})
+    posters   = images.get("posters", [])
+    logos     = images.get("logos", [])
+    backdrops = images.get("backdrops", [])
 
-    textless = [p for p in posters if p.get("iso_639_1") is None]
+    # iso_639_1 is None (JSON null) for most textless entries; older TMDB
+    # records occasionally use "" for the same thing — accept both.
+    textless = [p for p in posters if p.get("iso_639_1") in (None, "")]
 
     if textless:
         best = max(textless, key=lambda x: x.get("vote_average", 0))
@@ -158,9 +170,19 @@ async def fetch_poster_metadata(
         is_textless = False
 
     if not poster_path:
-        logger.warning(f"No poster image on TMDB for tmdb_id={tmdb_id} — fallback canvas will be served")
+        logger.warning(f"No poster image on TMDB for tmdb_id={tmdb_id} — backdrop or fallback canvas will be served")
         is_textless = False  # no art, no point fetching logos
-        # poster_path stays None; get_poster will generate a fallback canvas
+        # poster_path stays None; main.py picks backdrop_path or generates a canvas
+
+    # Best textless backdrop. Only consider null/unspecified-language entries —
+    # backdrops with an explicit language tag frequently have title text burned
+    # in. None if no neutral backdrop exists, which suppresses the fallback.
+    backdrop_candidates = [b for b in backdrops if b.get("iso_639_1") in (None, "")]
+    if backdrop_candidates:
+        best_backdrop = max(backdrop_candidates, key=lambda x: x.get("vote_average", 0))
+        backdrop_path: str | None = best_backdrop["file_path"]
+    else:
+        backdrop_path = None
 
     genre_ids            = [g["id"] for g in data.get("genres", [])]
     credits              = data.get("credits", {})
@@ -184,6 +206,7 @@ async def fetch_poster_metadata(
         runtime=runtime,
         number_of_seasons=number_of_seasons,
         number_of_episodes=number_of_episodes,
+        backdrop_path=backdrop_path,
     )
 
     tmdb_data = {
@@ -195,7 +218,7 @@ async def fetch_poster_metadata(
         "number_of_episodes":   number_of_episodes,
     }
 
-    return genre_ids, is_textless, logos, release_year, title, poster_path, tmdb_data
+    return genre_ids, is_textless, logos, release_year, title, poster_path, backdrop_path, tmdb_data
 
 
 async def resolve_imdb_to_tmdb(
@@ -275,6 +298,52 @@ async def fetch_poster_image(
     buf = io.BytesIO()
     image.convert("RGB").save(buf, format="JPEG", quality=92)
     set_cached_tmdb_poster(poster_cache_key, buf.getvalue())
+
+    return image
+
+
+async def fetch_backdrop_image(
+    client: httpx.AsyncClient,
+    tmdb_id: str,
+    backdrop_path: str,
+) -> Image.Image:
+    """
+    Fetch, centre-crop, and cache a TMDB backdrop as a portrait poster.
+
+    Backdrops are 16:9 landscape; we take the full height and cut a centred
+    2:3 strip, giving a clean textless portrait without any AI inpainting.
+    Cached under the same JPEG scheme as regular posters so subsequent hits
+    skip the upstream call. Used by main.py when fetch_poster_metadata
+    returns poster_path=None (no textless or default poster on TMDB).
+    """
+    cache_key = f"backdrop_{tmdb_id}_{backdrop_path.strip('/')}"
+    cached_bytes = get_cached_tmdb_poster(cache_key)
+
+    if cached_bytes:
+        logger.info(f"TMDB backdrop cache hit for {tmdb_id}")
+        image = Image.open(io.BytesIO(cached_bytes)).convert("RGBA")
+        if image.size != (POSTER_WIDTH, POSTER_HEIGHT):
+            image = normalise_poster(image)
+        return image
+
+    # w1280 gives enough resolution to crop to a quality portrait
+    logger.info(f"External API Call: Requested backdrop from TMDB for {tmdb_id}")
+    img_resp = await client.get(f"https://image.tmdb.org/t/p/w1280{backdrop_path}")
+    img_resp.raise_for_status()
+    image = Image.open(io.BytesIO(img_resp.content)).convert("RGBA")
+
+    # Centre-crop 16:9 → 2:3: keep full height, take a centred vertical strip
+    w, h = image.size
+    crop_w = int(h * 2 / 3)
+    if crop_w < w:
+        left = (w - crop_w) // 2
+        image = image.crop((left, 0, left + crop_w, h))
+
+    image = normalise_poster(image)
+
+    buf = io.BytesIO()
+    image.convert("RGB").save(buf, format="JPEG", quality=92)
+    set_cached_tmdb_poster(cache_key, buf.getvalue())
 
     return image
 


### PR DESCRIPTION
## Summary

Upstream [`5b124ca` "Release v1.0.0"](https://github.com/UmbraProjects/PostersPlus/commit/5b124ca6a6fa16a99a66916ae3745da73a12cd17) squashed ~1500 lines of development into a single commit. Triaged and applied a focused subset that aligns with our hosted-mode posture; skipped the parts that conflict.

## What's in

**Security + correctness:**
- **Range-clamped numeric query params** — caps `score_glow_blur` at 50, `badge_height` at 200px, ratios at 0.0–1.5 etc. Stops malicious or careless values from melting a worker.
- **Expanded log redaction** — `_TruncateUrlFilter` now scrubs API keys from `record.msg`, `record.args`, and pre-formats `record.exc_text` so tracebacks can't leak keys via httpx exception `__str__`.
- **`draw_score_bar` score=0 fix** — empty track now rendered instead of disappearing.

**Features:**
- **Backdrop fallback** — `tmdb_metadata_cache.backdrop_path` column (idempotent migrations both backends), new `fetch_backdrop_image` centre-crops 16:9 → 2:3. Ladder: poster → backdrop → canvas. Wired into both `/poster` and `/p`.
- **Genre-tinted fallback canvas** — atmospheric per-genre RGB tint when neither poster nor backdrop exists.
- **`MDBLIST_CONCURRENCY` semaphore** (default 3) — caps concurrent outbound MDBlist calls so a poster burst doesn't trip MDBlist's per-key connection cap.

## What's out (deliberate)

- **pycairo + Badge Style sash** — system dep cost outweighs the cosmetic alternative
- **requirements.txt strict pinning** — conflicts with our hosted-mode deps
- **gosu / multi-platform Docker** — we use containers-private + k8s
- **MDBlist escalating backoff + global cooldown** — conflicts with our Phase 2 coord-backed shared backoff
- **Configurator info modals** — UX nicety, not preset-tier critical

## What was already in the fork

Phase 5 already landed `gg_wins`/`gg_noms` split + Emmy Outstanding restrict; Phase 1 already has `_safe_cache_path`. Composite cache, rating/render coalescing, lifespan cancellation, /health, /server-caps, CDN_CACHE_TTL — all already present.

Full breakdown in [RESILIENCE.md "Selective port — upstream v1.0.0"](RESILIENCE.md).

## Codex review

First pass clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)