### PR TITLE
fix: propagate blob-put failures so orphan metadata rows aren't written

### DIFF
--- a/blobstore/local.py
+++ b/blobstore/local.py
@@ -86,7 +86,12 @@ def _put_sync(bucket: str, key: str, data: bytes) -> None:
             f.write(data)
         os.replace(tmp_path, path)
     except Exception as exc:
+        # Propagate so set_cached_final_poster can skip writing the
+        # metadata row. Same contract as the S3 backend — a metadata
+        # row pointing at a missing blob would cause subsequent cache
+        # hits to serve nothing (or 302 to a missing URL) until TTL.
         logger.error(f"Blob cache write error for {bucket}:{key}: {exc}")
+        raise
 
 
 def _delete_sync(bucket: str, key: str) -> None:

--- a/blobstore/s3.py
+++ b/blobstore/s3.py
@@ -148,7 +148,12 @@ def _put_sync(bucket: str, key: str, data: bytes, content_type: str | None) -> N
     try:
         _client.put_object(**kwargs)
     except ClientError as exc:
+        # Propagate so set_cached_final_poster can skip writing the
+        # metadata row. Swallowing here left an orphaned row pointing at
+        # an object that was never written — subsequent cache hits 302'd
+        # clients at a missing CDN URL until COMPOSITE_CACHE_TTL elapsed.
         logger.warning(f"S3 PUT error for {obj_key}: {exc}")
+        raise
 
 
 def _delete_sync(bucket: str, key: str) -> None:


### PR DESCRIPTION
## Summary

Phase 10 hardening follow-up. Both blobstore backends (\`s3.py\` and \`local.py\`) were swallowing \`_put_sync\` errors — just logging and returning normally. The outer \`set_cached_final_poster\` in each storage backend already orders the calls correctly (blob first, then metadata row) and wraps both in try/except — but a swallowed put meant the metadata row got written anyway, pointing at an object that was never persisted.

On a CDN-enabled instance that left clients 302'ing to a missing URL until \`COMPOSITE_CACHE_TTL\` elapsed (7 days). One \`raise\` in each backend's \`_put_sync\` lets the outer storage-layer \`except\` catch it, log "Final poster cache write error", and skip the metadata row. Subsequent requests re-render normally.

Codex review clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)