### PR TITLE
fix: reload preview when preset dropdown changes

### DIFF
--- a/configurator.html
+++ b/configurator.html
@@ -2761,6 +2761,11 @@ function refreshPresetUiState() {
 function onPresetChange() {
   refreshPresetUiState();
   build();
+  // Every other control pairs build() with queuePreviewReload() so the
+  // right-panel preview re-fetches when the emitted URL changes; the
+  // preset dropdown was missing the second call, so the URL text
+  // updated but the preview stayed pinned to the previous render.
+  queuePreviewReload();
 }
 
 function buildBaseParams({ usePlaceholders = false } = {}) {


### PR DESCRIPTION
Trivial one-line fix. `onPresetChange()` updated the URL but didn't call `queuePreviewReload()` so the live preview stayed pinned to the previous render. Every other configurator control pairs `build()` with `queuePreviewReload()` — the preset dropdown was missing the second call.