### PR TITLE
feat: build-version footer + align to upstream v1.0.0

### DIFF
--- a/configurator.html
+++ b/configurator.html
@@ -1128,6 +1128,28 @@
   }
   .lock-banner-sponsor a:hover { color: var(--gold); }
 
+  /* Build footer — sits at the bottom of the shell, below the main
+     two-column layout. Subtle styling so it's a foot-of-page credit
+     rather than a UI element. */
+  .build-footer {
+    margin-top: 24px;
+    padding: 14px 0 20px;
+    border-top: 1px solid var(--border);
+    text-align: center;
+    font-family: var(--mono);
+    font-size: 9px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+  }
+  .build-footer a {
+    color: var(--silver-dim);
+    text-decoration: none;
+    transition: color 0.15s;
+  }
+  .build-footer a:hover { color: var(--gold); }
+  .build-footer-version { color: var(--gold-dim); }
+
   /* Anything below Core Config (i.e. the visual configuration sections)
      is locked out when preset-only-mode is active. The user can still
      SEE the sections but can't interact with them — a discoverability
@@ -2017,6 +2039,16 @@
     </div>
   </div>
 
+  <!-- Build footer. version + repo link populated at boot from
+       /server-caps so a fresh image always reports its own release. -->
+  <footer class="build-footer">
+    <a href="https://github.com/elfhosted/PostersPlus"
+       target="_blank" rel="noopener noreferrer">
+      ElfHosted HA public build
+      <span id="build-version" class="build-footer-version">·&nbsp;dev</span>
+    </a>
+  </footer>
+
 </div>
 
 <script>
@@ -2162,6 +2194,13 @@ async function fetchServerCaps() {
   // unlocked state.
   try { applyLockMode(); }   catch(e) { console.warn('applyLockMode failed', e); }
   try { updateKeyBadges(); } catch(e) { console.warn('updateKeyBadges failed', e); }
+  // Build version footer: populate from serverCaps.version. Server
+  // returns "dev" when version.txt is missing (run-local.py against an
+  // untagged tree) — keep that as-is rather than hiding the footer.
+  const versionEl = document.getElementById('build-version');
+  if (versionEl && serverCaps.version) {
+    versionEl.textContent = '· v' + serverCaps.version;
+  }
 }
 
 function updateKeyBadges() {

--- a/main.py
+++ b/main.py
@@ -989,6 +989,16 @@ BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 _FONTS_DIR = os.path.join(BASE_DIR, "fonts")
 app.mount("/static", StaticFiles(directory=os.path.join(BASE_DIR, "static")), name="static")
 
+# Build version surfaced via /server-caps so the configurator footer can
+# display it. release-please rewrites version.txt on every release PR,
+# so a fresh image always reports its own tag. Missing file falls back
+# to "dev" — useful when running run-local.py against an untagged tree.
+try:
+    with open(os.path.join(BASE_DIR, "version.txt"), "r", encoding="utf-8") as _f:
+        _BUILD_VERSION = _f.read().strip() or "dev"
+except FileNotFoundError:
+    _BUILD_VERSION = "dev"
+
 
 @app.middleware("http")
 async def remove_server_header(request: Request, call_next):
@@ -1033,6 +1043,7 @@ async def server_caps(access_key: str = ""):
         "preset_enabled":        _cfg.PRESET_ENABLED,
         "presets":               preset_names() if _cfg.PRESET_ENABLED else [],
         "access_key_valid":      access_key_valid,
+        "version":               _BUILD_VERSION,
     }
 
 


### PR DESCRIPTION
## Summary

Bundled because the second change only makes sense once the first is in place.

**1. Build footer**

- `/server-caps` now reports the build version (read from `version.txt` at app startup, falls back to `dev` for untagged trees).
- Configurator gets a small `<footer>` at the bottom of the shell reading `ElfHosted HA public build · vX.Y.Z` and linking to the [elfhosted/PostersPlus](https://github.com/elfhosted/PostersPlus) repo. Subtle styling — credit, not a UI element.

**2. Align version to upstream v1.0.0**

Upstream [UmbraProjects/PostersPlus](https://github.com/UmbraProjects/PostersPlus) is at v1.0.0; this fork has been on its own release-please 0.x track since Phase 0 but incorporates upstream's v1.0.0 feature set (selective port landed in v0.5.0). Using release-please's `Release-As: 1.0.0` footer to skip 0.7-0.9 and align so the footer reads `v1.0.0` matching upstream.

Going forward release-please continues normally from 1.0.0. When upstream bumps to v1.1+ we'll `Release-As` again to re-sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)