### PR TITLE
fix: gate preview expand on mobile viewport (upstream v1.0.3)

### DIFF
--- a/configurator.html
+++ b/configurator.html
@@ -2122,7 +2122,17 @@ function _unlockScroll() {
   window.scrollTo(0, _scrollY);
 }
 
+// The "expanded" preview panel only renders visibly on mobile — the desktop
+// layout has the live preview always-visible in the right column.  Skipping
+// expand entirely on desktop avoids a hard-to-discover scroll lock that
+// fires invisibly when users click anywhere in the right column (a real
+// problem on instances that embed the configurator below a banner / nav
+// where the page actually needs to scroll).
+const _MOBILE_MQ = window.matchMedia('(max-width: 960px)');
+function _isMobileViewport() { return _MOBILE_MQ.matches; }
+
 function expandPreview() {
+  if (!_isMobileViewport()) return;
   previewPanel.classList.add('expanded');
   _lockScroll();
   history.pushState({ previewExpanded: true }, '');
@@ -2140,6 +2150,17 @@ function collapsePreview() {
 // Back gesture / button: collapse the panel instead of leaving the page.
 window.addEventListener('popstate', () => {
   if (previewPanel.classList.contains('expanded')) {
+    previewPanel.classList.remove('expanded');
+    _unlockScroll();
+  }
+});
+
+// If the viewport crosses into desktop while the panel is expanded (e.g.
+// device rotated to landscape past 960px, or browser window resized), the
+// "expanded" CSS becomes a no-op but the body scroll lock would persist.
+// Collapse + unlock on the transition so the user is never stranded.
+_MOBILE_MQ.addEventListener('change', (ev) => {
+  if (!ev.matches && previewPanel.classList.contains('expanded')) {
     previewPanel.classList.remove('expanded');
     _unlockScroll();
   }


### PR DESCRIPTION
## Summary

Cherry-pick of upstream [UmbraProjects/PostersPlus@faa94e0](https://github.com/UmbraProjects/PostersPlus/commit/faa94e0) (released as upstream v1.0.3).

- Gate `expandPreview()` on `window.matchMedia('(max-width: 960px)')` so the click-to-expand handler is a no-op on desktop
- Add a media-query change listener to collapse + unlock if the viewport crosses from mobile to desktop while expanded

## Why this matters here

Upstream's commit message names this fork specifically: "broken on instances that embed the configurator below a banner / nav (ElfHosted) — users could lock themselves into needing an F5." On desktop the `.expanded` CSS is a no-op (rules live inside `@media max-width: 960px`) so users saw no visual change when clicking the right column, but `_lockScroll()` still ran and the page became unscrollable.

## Notes

- Code matches upstream verbatim to keep future cherry-picks clean
- Codex review surfaced one [P2] nit: `MediaQueryList.addEventListener` isn't available in Safari/iOS WebViews predating v14 (Sept 2020); a `addListener` fallback would catch those. Deferred — upstream's maintainer accepted the same code, and Safari 14 is 5+ years old. Trivial to add later if needed.
- Skipped upstream v1.0.2 entirely: those fixes targeted defaults for the `sash_badge` feature (which this fork doesn't have) and a slider-vs-server-default drift on `score_glow_blur` (which we don't have either — our `config.SCORE_GLOW_BLUR = 2` agrees with the slider).

## Test plan

- [ ] Open the configurator on desktop (>960px), click the right-column preview area, confirm the page still scrolls
- [ ] Open on mobile (<=960px) or with DevTools at 960px, tap the collapsed preview, confirm it expands and scroll-lock engages
- [ ] On mobile/expanded, resize the window past 960px and confirm the panel collapses and scroll unlocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)