### PR TITLE
fix: fall back to TMDB-derived genre when MDBlist is unreachable

### DIFF
--- a/main.py
+++ b/main.py
@@ -1664,6 +1664,20 @@ async def get_poster(
             await fetch_poster_metadata(client, tmdb_id, effective_tmdb_key, type)
         )
 
+        # TMDB genre_ids are always present when the metadata fetch succeeds,
+        # so we resolve a genre label up-front to use as a fallback whenever
+        # MDBlist is unreachable, rate-limited, or unkeyed. Without this, an
+        # exhausted MDBlist key turns every poster's genre tag into "Unknown".
+        _tmdb_genre = "Unknown"
+        if genre_ids:
+            _gid_set = set(genre_ids)
+            for _gid in _cfg.GENRE_PRIORITY:
+                if _gid in _gid_set:
+                    _candidate = _cfg.GENRE_MAP.get(_gid, "")
+                    if _candidate:
+                        _tmdb_genre = _candidate
+                        break
+
         if rating_already_cached or not effective_mdblist_key:
             rating_coro = _resolved(
                 (cached_ratings_dict, cached_genre, cached_release_date, [], cached_age_rating)
@@ -1718,7 +1732,7 @@ async def get_poster(
             await coord.set_backoff(coord.NS_RATING_BACKOFF, imdb_id, ttl_seconds=3600.0)
             logger.info(f"MDBlist back-off set for {imdb_id} (1 hour)")
             ratings_dict   = {}
-            genre          = cached_genre or "Unknown"
+            genre          = cached_genre or _tmdb_genre
             rel            = cached_release_date
             score          = "N/A"
             keywords       = []
@@ -1731,6 +1745,10 @@ async def get_poster(
             is_metacritic  = cached_is_metacritic
         else:
             ratings_dict, genre, rel, keywords, age_rating = rating_result
+            # cached_genre may be None when there's no MDBlist key configured
+            # and nothing has been cached for this title yet — fall back to
+            # the TMDB-derived genre so the badge still renders.
+            genre = genre or _tmdb_genre
 
             if isinstance(ratings_dict, dict):
                 weights = (


### PR DESCRIPTION
## Summary

- When the operator's MDBlist key is exhausted, rate-limited, or absent, `fetch_rating` returns `FETCH_FAILED` and the rating-failed branch hardcoded `genre = cached_genre or "Unknown"`. Result: every poster's genre tag rendered as **Unknown** until the key reset.
- Derive `_tmdb_genre` from the TMDB `genre_ids` returned by `fetch_poster_metadata` (independent of MDBlist) and use it as the fallback in both the rating-failed branch and the success branch where `cached_genre` may be `None`.
- This is a port of a fix that landed upstream in UmbraProjects/PostersPlus v1.0.0. Our PR #11 ("selective port of upstream v1.0.0") missed it.

## Context

Upstream dev confirmed the behaviour: *"that's the behaviour when Mdblist either isn't replying or the keys out... Genres was fixed in v1.01 or v1.02 but I don't think it ended up merged."* (The fix actually landed in upstream's v1.0.0 release commit, not v1.0.1/1.0.2.)

## Version

This is a fork-only patch on top of v1.0.3, so per the [version-mirror policy](https://github.com/elfhosted/PostersPlus/blob/main/README.md#relationship-to-upstream) the commit footer is `Release-As: 1.0.3-elf.1` — first fork-only `-elf.N` since the upstream-aligned `v1.0.3`.

## Test plan

- [ ] Render a poster with `MDBLIST_API_KEY` unset → genre tag shows the TMDB-derived genre (e.g. "Drama"), not "Unknown"
- [ ] Render a poster while MDBlist is returning 429 → genre tag survives, score correctly renders N/A
- [ ] Render a poster with a valid MDBlist key → no behaviour change (genre still comes from `fetch_rating`)
- [ ] Cached rating row with non-null `genre` still wins over `_tmdb_genre` in both branches

🤖 Generated with [Claude Code](https://claude.com/claude-code)