### PR TITLE
fix: derive preset genre from TMDB when rating is uncached

### DIFF
--- a/main.py
+++ b/main.py
@@ -2296,6 +2296,21 @@ async def get_preset_poster(
             await fetch_poster_metadata(client, tmdb_id, effective_tmdb_key, type)
         )
 
+        # TMDB-derived genre fallback. The preset path deliberately never
+        # calls MDBlist, so for any title that hasn't been warmed by a
+        # paid /poster call cached_genre is None (or absent entirely) and
+        # `genre` was set to literal "Unknown" above. Derive a label from
+        # TMDB's genre_ids — same logic /poster uses — so preset posters
+        # don't render with "Unknown" for the common "never-warmed" case.
+        if genre == "Unknown" and genre_ids:
+            _gid_set = set(genre_ids)
+            for _gid in _cfg.GENRE_PRIORITY:
+                if _gid in _gid_set:
+                    _candidate = _cfg.GENRE_MAP.get(_gid, "")
+                    if _candidate:
+                        genre = _candidate
+                        break
+
         # No-poster fallback ladder (same as /poster):
         #   1. poster_path  → textless or default poster
         #   2. backdrop_path → landscape backdrop centre-cropped to portrait


### PR DESCRIPTION
## Summary

PR #24 (v1.0.3-elf.1) fixed the "Genre: Unknown" issue for `/poster` by deriving genre from TMDB's `genre_ids` when MDBlist data wasn't available. But the `/p/{preset}/{type}/{imdb_id}.jpg` endpoint is a separate, fork-only code path with its own genre-resolution block — it deliberately never calls MDBlist (so anonymous preset traffic can't burn the operator's quota), and for any title that hasn't been warmed by a paid `/poster` call `cached_rating` is `None` and `genre` was being set to literal `"Unknown"`.

Result on the public instance: every "first-hit" preset render ships with `"Genre: Unknown"` until a sister `/poster` call populates the rating cache for that imdb_id. Confirmed reproducer: `https://posters.elfhosted.com/p/minimalist/movie/tt0304141.jpg` (Harry Potter and the Prisoner of Azkaban) renders with `Unknown 2004` instead of `Adventure 2004`.

## Fix

Apply the same TMDB-derived genre walk that `/poster` has used since elf.1, right after `fetch_poster_metadata` returns `genre_ids`. If `genre` is still the placeholder `"Unknown"`, walk `GENRE_PRIORITY` and pick the highest-ranked match from TMDB's `genre_ids`.

## Test plan

- [ ] Hit `https://posters.elfhosted.com/p/minimalist/movie/tt0304141.jpg` on the public instance after deploy; expect `Adventure 2004` (TMDB's genre_ids for that title are `[12 Adventure, 14 Fantasy]` — Adventure wins because Fantasy is at index 8 in GENRE_PRIORITY and Adventure is at index 20, wait actually Fantasy is higher priority, so it'd be `Fantasy 2004`)
- [ ] Hit `https://posters.elfhosted.com/p/minimalist/movie/tt2911666.jpg` (John Wick — TMDB genres Action+Thriller); expect `Thriller 2014` (Thriller is index 1 in priority, beats Action at index 11)
- [ ] Spot-check a few never-warmed titles; expect genre to no longer say `Unknown` unless TMDB itself has no genre_ids on the title

🤖 Generated with [Claude Code](https://claude.com/claude-code)