### PR TITLE
fix: real version in header What's-New chip (v1.1.0-elf.3)

### DIFF
--- a/configurator.html
+++ b/configurator.html
@@ -3265,6 +3265,13 @@ async function fetchServerCaps() {
   if (versionEl && serverCaps.version) {
     versionEl.textContent = '· v' + serverCaps.version;
   }
+  // Upstream's "What's New" chip is hardcoded to a vX.Y-dev placeholder in the
+  // markup; surface the real fork build version there too so the header doesn't
+  // read "dev" on a released build.
+  const whatsNewEl = document.getElementById('whatsnew-version');
+  if (whatsNewEl && serverCaps.version) {
+    whatsNewEl.textContent = 'v' + serverCaps.version;
+  }
 }
 
 // ── ELFHOSTED FORK: PUBLIC-TIER LOCK ─────────────────────────────────────────


### PR DESCRIPTION
The elf.2 fix wired the bottom build footer to the real version, but the prominent header indicator users see is upstream's hardcoded What's-New chip (vX.Y-dev). Populate it from serverCaps.version too. Cuts v1.1.0-elf.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)