### PR TITLE
fix: stop release-please aborting auto-tag (empty component)

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,7 +10,7 @@
   "packages": {
     ".": {
       "release-type": "simple",
-      "package-name": "postersplus",
+      "component": "",
       "extra-files": [
         "version.txt"
       ]


### PR DESCRIPTION
Every release since the rebuild needed a manual tag — the Release-Please run aborted with "untagged, merged release PRs outstanding". Root cause: package-name set component to "postersplus" but include-component-in-tag:false makes the release lookup use an empty component, and the PR title carries no component to round-trip — so they never match. Set component to "" for consistency. This release (elf.7) is the live test of the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)